### PR TITLE
Putting back datepicker languages resources updated to JQuery 1.12.1.

### DIFF
--- a/wiquery-jquery-ui/src/main/java/org/wicketstuff/wiquery/ui/datepicker/DatePicker.java
+++ b/wiquery-jquery-ui/src/main/java/org/wicketstuff/wiquery/ui/datepicker/DatePicker.java
@@ -153,6 +153,11 @@ public class DatePicker<T> extends TextField<T>
 		response
 			.render(JavaScriptHeaderItem.forReference(JQueryUIJavaScriptResourceReference.get()));
 
+		DatePickerLanguageResourceReference dpl =
+			DatePickerLanguageResourceReference.get(getLocale());
+		if (dpl != null)
+			response.render(JavaScriptHeaderItem.forReference(dpl));
+
 		response.render(OnDomReadyHeaderItem.forScript(new JsQuery(this).$()
 			.chain("datepicker", options.getOptions().getJavaScriptOptions())
 			.render()

--- a/wiquery-jquery-ui/src/main/java/org/wicketstuff/wiquery/ui/datepicker/DatePickerLanguageResourceReference.java
+++ b/wiquery-jquery-ui/src/main/java/org/wicketstuff/wiquery/ui/datepicker/DatePickerLanguageResourceReference.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2009 WiQuery team
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.wicketstuff.wiquery.ui.datepicker;
+
+import java.util.Locale;
+
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
+
+/**
+ * $Id$
+ * <p>
+ * Provides a JavaScript reference to display the date picker labels for a given local.
+ * </p>
+ * 
+ * @author Lionel Armanet
+ * @since 0.6
+ */
+public class DatePickerLanguageResourceReference extends JavaScriptResourceReference
+{
+	/**
+	 * Enumeration of possibles alternatives languages for the DatePicker (Default locale
+	 * for the DatePicker : EN)
+	 * 
+	 * @author Julien Roche
+	 * @note Hielke Hoeve: ordered languages by order of appearance on the file system.
+	 *       There are 3 countries whom have had their ISO code changed. Java has an ugly
+	 *       fix to fix this which we are stuck with... We copied the resource files to
+	 *       reflect both country codes, while Java only uses one of them...
+	 */
+	public enum DatePickerLanguages
+	{
+		AFRIKAANS("af"),
+		ALGERIAN("ar", "DZ"),
+		ARABIC("ar"),
+		AZERBAIJANI("az"),
+		BELARUSIAN("be"),
+		BULGARIAN("bg"),
+		BOSNIAN("bs"),
+		CATALAN("ca"),
+		CZECH("cs"),
+		DANISH("da"),
+		GERMAN(Locale.GERMAN),
+		GREEK("el"),
+		AUSTRALIAN("en", "AU"),
+		UNITED_KINGDOM(Locale.UK),
+		NEW_ZEALAND("en", "NZ"),
+		ESPERANTO("eo"),
+		SPANISH("es"),
+		ESTONIAN("et"),
+		EUSKARAKO("eu"),
+		PERSIAN("fa"),
+		FINNISH("fi"),
+		FAROESE("fo"),
+		SWISS("fr", "CH"),
+		FRENCH(Locale.FRENCH),
+		GALICIAN("gl"),
+		HEBREW("he"),
+		// HEBREW_OLD ("iw"),
+		CROATIAN("hr"),
+		HUNGARIAN("hu"),
+		ARMENIAN("hy"),
+		INDONESIAN("id"),
+		// INDONESIAN_OLD ("in"),
+		ICELANDIC("is"),
+		SWISS_ITALIAN("it", "CH"),
+		ITALIAN(Locale.ITALIAN),
+		JAPANESE(Locale.JAPANESE),
+		KOREAN(Locale.KOREAN),
+		KAZAKH("kz"),
+		LITHUANIAN("lt"),
+		LATVIAN("lv"),
+		MALAYALAM("ml"),
+		MALAYSIAN("ms"),
+		DUTCH("nl"),
+		NORVEGIAN("no"),
+		POLISH("pl"),
+		BRAZILIAN("pt", "BR"),
+		PORTUGUESE("pt"),
+		ROMANSH("rm"),
+		ROMANIAN("ro"),
+		RUSSIAN("ru"),
+		SLOVAK("sk"),
+		SLOVENIAN("sl"),
+		ALBANIAN("sq"),
+		SERBIA("sr", "SR"),
+		SERBIAN("sr"),
+		SWEDISH("sv"),
+		TAMIL("ta"),
+		THAI("th"),
+		TAJIKISTAN("tj"),
+		TURKISH("tr"),
+		UKRAINIAN("uk"),
+		VIETNAMESE("vi"),
+		SIMPLIFIED_CHINESE(Locale.SIMPLIFIED_CHINESE),
+		CHINESE("zh", "HK"),
+		TRADITIONAL_CHINESE(Locale.TRADITIONAL_CHINESE);
+
+		// Properties
+		private final Locale locale;
+
+		/**
+		 * Constructor
+		 * 
+		 * @param locale
+		 */
+		DatePickerLanguages(Locale locale)
+		{
+			this.locale = locale;
+		}
+
+		/**
+		 * Constructor
+		 * 
+		 * @param language
+		 */
+		DatePickerLanguages(String language)
+		{
+			this.locale = new Locale(language);
+		}
+
+		/**
+		 * Constructor
+		 * 
+		 * @param language
+		 * @param country
+		 */
+		DatePickerLanguages(String language, String country)
+		{
+			this.locale = new Locale(language, country);
+		}
+
+		/**
+		 * Constructor
+		 * 
+		 * @param language
+		 * @param country
+		 * @param variant
+		 */
+		DatePickerLanguages(String language, String country, String variant)
+		{
+			this.locale = new Locale(language, country, variant);
+		}
+
+		/**
+		 * @return the locale
+		 */
+		public Locale getLocale()
+		{
+			return locale;
+		}
+
+		/**
+		 * Try to find the most appropriate value in the enumeration
+		 * 
+		 * @param locale
+		 *            Locale to search
+		 * @return the value
+		 */
+		public static DatePickerLanguages getDatePickerLanguages(Locale locale)
+		{
+			if (locale == null)
+				return null;
+
+			Locale tmpLocale = null;
+			String language = locale.getLanguage();
+			String country = locale.getCountry();
+			String variant = locale.getVariant();
+			String empty = "";
+
+			country = country == null || country.trim().length() <= 0 ? null : country;
+			variant = variant == null || variant.trim().length() <= 0 ? null : variant;
+
+			// Equals on language-country-variant
+			if (variant != null)
+			{
+				for (DatePickerLanguages l : values())
+				{
+					tmpLocale = l.getLocale();
+
+					if (tmpLocale.getLanguage().equals(language)
+						&& tmpLocale.getCountry().equals(country)
+						&& tmpLocale.getVariant().equals(variant))
+					{
+						return l;
+					}
+				}
+			}
+
+			// Equals on language-country
+			if (country != null)
+			{
+				for (DatePickerLanguages l : values())
+				{
+					tmpLocale = l.getLocale();
+
+					if (tmpLocale.getLanguage().equals(language)
+						&& tmpLocale.getCountry().equals(country)
+						&& tmpLocale.getVariant().equals(empty))
+					{
+						return l;
+					}
+				}
+			}
+
+			// Equals on language
+			for (DatePickerLanguages l : values())
+			{
+				tmpLocale = l.getLocale();
+
+				if (tmpLocale.getLanguage().equals(language)
+					&& tmpLocale.getCountry().equals(empty) && tmpLocale.getVariant().equals(empty))
+				{
+					return l;
+				}
+			}
+
+			return null;
+		}
+
+		/**
+		 * Method calculating the name of the jQuery UI Locale file
+		 * 
+		 * @param dpl
+		 *            Language to use
+		 * @return the filename
+		 */
+		public static String getJsFileName(DatePickerLanguages dpl)
+		{
+			if (dpl == null)
+			{
+				return null;
+			}
+
+			Locale locale = dpl.getLocale();
+			String country = locale.getCountry();
+			String variant = locale.getVariant();
+			StringBuilder js = new StringBuilder();
+
+			js.append("i18n/datepicker-");
+			js.append(locale.getLanguage());
+
+			if (country != null && country.trim().length() > 0)
+			{
+				js.append('-').append(country);
+
+				if (variant != null && variant.trim().length() > 0)
+				{
+					js.append('-').append(variant);
+				}
+			}
+
+			js.append(".js");
+
+			return js.toString();
+		}
+	}
+
+	// Constants
+	/** Constant of serialization */
+	private static final long serialVersionUID = 5955164494361831059L;
+
+	protected DatePickerLanguageResourceReference(Locale locale, String filename)
+	{
+		super(DatePickerLanguageResourceReference.class, filename, locale, null, null);
+	}
+
+	/**
+	 * @param locale
+	 *            providing an unknown locale will return null, because Locale US, EN and
+	 *            EN_US are already included in the datepicker js file.
+	 * @return an DatePickerLanguageResourceReference if the locale is known within our
+	 *         DatePickerLanguages class.
+	 */
+	public static DatePickerLanguageResourceReference get(Locale locale)
+	{
+		DatePickerLanguages dpl = DatePickerLanguages.getDatePickerLanguages(locale);
+
+		if (dpl != null)
+			return new DatePickerLanguageResourceReference(locale,
+				DatePickerLanguages.getJsFileName(dpl));
+
+		return null;
+	}
+}

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-af.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-af.js
@@ -1,0 +1,37 @@
+/* Afrikaans initialisation for the jQuery UI date picker plugin. */
+/* Written by Renier Pretorius. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.af = {
+	closeText: "Selekteer",
+	prevText: "Vorige",
+	nextText: "Volgende",
+	currentText: "Vandag",
+	monthNames: [ "Januarie","Februarie","Maart","April","Mei","Junie",
+	"Julie","Augustus","September","Oktober","November","Desember" ],
+	monthNamesShort: [ "Jan", "Feb", "Mrt", "Apr", "Mei", "Jun",
+	"Jul", "Aug", "Sep", "Okt", "Nov", "Des" ],
+	dayNames: [ "Sondag", "Maandag", "Dinsdag", "Woensdag", "Donderdag", "Vrydag", "Saterdag" ],
+	dayNamesShort: [ "Son", "Maa", "Din", "Woe", "Don", "Vry", "Sat" ],
+	dayNamesMin: [ "So","Ma","Di","Wo","Do","Vr","Sa" ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.af );
+
+return datepicker.regional.af;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ar-DZ.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ar-DZ.js
@@ -1,0 +1,39 @@
+/* Algerian Arabic Translation for jQuery UI date picker plugin.
+/* Used in most of Maghreb countries, primarily in Algeria, Tunisia, Morocco.
+/* Mohamed Cherif BOUCHELAGHEM -- cherifbouchelaghem@yahoo.fr */
+/* Mohamed Amine HADDAD -- zatamine@gmail.com */
+
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "ar-DZ" ] = {
+	closeText: "إغلاق",
+	prevText: "&#x3C;السابق",
+	nextText: "التالي&#x3E;",
+	currentText: "اليوم",
+	monthNames: [ "جانفي", "فيفري", "مارس", "أفريل", "ماي", "جوان",
+	"جويلية", "أوت", "سبتمبر","أكتوبر", "نوفمبر", "ديسمبر" ],
+	monthNamesShort: [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" ],
+	dayNames: [ "الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت" ],
+	dayNamesShort: [ "الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت" ],
+	dayNamesMin: [ "ح", "ن", "ث", "ر", "خ", "ج", "س" ],
+	weekHeader: "أسبوع",
+	dateFormat: "dd/mm/yy",
+	firstDay: 6,
+		isRTL: true,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "ar-DZ" ] );
+
+return datepicker.regional[ "ar-DZ" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ar.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ar.js
@@ -1,0 +1,39 @@
+/* Arabic Translation for jQuery UI date picker plugin. */
+/* Used in most of Arab countries, primarily in Bahrain, */
+/* Kuwait, Oman, Qatar, Saudi Arabia and the United Arab Emirates, Egypt, Sudan and Yemen. */
+/* Written by Mohammed Alshehri -- m@dralshehri.com */
+
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ar = {
+	closeText: "إغلاق",
+	prevText: "&#x3C;السابق",
+	nextText: "التالي&#x3E;",
+	currentText: "اليوم",
+	monthNames: [ "يناير", "فبراير", "مارس", "أبريل", "مايو", "يونيو",
+	"يوليو", "أغسطس", "سبتمبر", "أكتوبر", "نوفمبر", "ديسمبر" ],
+	monthNamesShort: [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" ],
+	dayNames: [ "الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت" ],
+	dayNamesShort: [ "أحد", "اثنين", "ثلاثاء", "أربعاء", "خميس", "جمعة", "سبت" ],
+	dayNamesMin: [ "ح", "ن", "ث", "ر", "خ", "ج", "س" ],
+	weekHeader: "أسبوع",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+		isRTL: true,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ar );
+
+return datepicker.regional.ar;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-az.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-az.js
@@ -1,0 +1,37 @@
+/* Azerbaijani (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Jamil Najafov (necefov33@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.az = {
+	closeText: "Bağla",
+	prevText: "&#x3C;Geri",
+	nextText: "İrəli&#x3E;",
+	currentText: "Bugün",
+	monthNames: [ "Yanvar","Fevral","Mart","Aprel","May","İyun",
+	"İyul","Avqust","Sentyabr","Oktyabr","Noyabr","Dekabr" ],
+	monthNamesShort: [ "Yan","Fev","Mar","Apr","May","İyun",
+	"İyul","Avq","Sen","Okt","Noy","Dek" ],
+	dayNames: [ "Bazar","Bazar ertəsi","Çərşənbə axşamı","Çərşənbə","Cümə axşamı","Cümə","Şənbə" ],
+	dayNamesShort: [ "B","Be","Ça","Ç","Ca","C","Ş" ],
+	dayNamesMin: [ "B","B","Ç","С","Ç","C","Ş" ],
+	weekHeader: "Hf",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.az );
+
+return datepicker.regional.az;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-be.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-be.js
@@ -1,0 +1,37 @@
+/* Belarusian initialisation for the jQuery UI date picker plugin. */
+/* Written by Pavel Selitskas <p.selitskas@gmail.com> */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.be = {
+	closeText: "Зачыніць",
+	prevText: "&larr;Папяр.",
+	nextText: "Наст.&rarr;",
+	currentText: "Сёньня",
+	monthNames: [ "Студзень","Люты","Сакавік","Красавік","Травень","Чэрвень",
+	"Ліпень","Жнівень","Верасень","Кастрычнік","Лістапад","Сьнежань" ],
+	monthNamesShort: [ "Сту","Лют","Сак","Кра","Тра","Чэр",
+	"Ліп","Жні","Вер","Кас","Ліс","Сьн" ],
+	dayNames: [ "нядзеля","панядзелак","аўторак","серада","чацьвер","пятніца","субота" ],
+	dayNamesShort: [ "ндз","пнд","аўт","срд","чцв","птн","сбт" ],
+	dayNamesMin: [ "Нд","Пн","Аў","Ср","Чц","Пт","Сб" ],
+	weekHeader: "Тд",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.be );
+
+return datepicker.regional.be;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-bg.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-bg.js
@@ -1,0 +1,38 @@
+/* Bulgarian initialisation for the jQuery UI date picker plugin. */
+/* Written by Stoyan Kyosev (http://svest.org). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.bg = {
+	closeText: "затвори",
+	prevText: "&#x3C;назад",
+	nextText: "напред&#x3E;",
+	nextBigText: "&#x3E;&#x3E;",
+	currentText: "днес",
+	monthNames: [ "Януари","Февруари","Март","Април","Май","Юни",
+	"Юли","Август","Септември","Октомври","Ноември","Декември" ],
+	monthNamesShort: [ "Яну","Фев","Мар","Апр","Май","Юни",
+	"Юли","Авг","Сеп","Окт","Нов","Дек" ],
+	dayNames: [ "Неделя","Понеделник","Вторник","Сряда","Четвъртък","Петък","Събота" ],
+	dayNamesShort: [ "Нед","Пон","Вто","Сря","Чет","Пет","Съб" ],
+	dayNamesMin: [ "Не","По","Вт","Ср","Че","Пе","Съ" ],
+	weekHeader: "Wk",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.bg );
+
+return datepicker.regional.bg;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-bs.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-bs.js
@@ -1,0 +1,37 @@
+/* Bosnian i18n for the jQuery UI date picker plugin. */
+/* Written by Kenan Konjo. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.bs = {
+	closeText: "Zatvori",
+	prevText: "&#x3C;",
+	nextText: "&#x3E;",
+	currentText: "Danas",
+	monthNames: [ "Januar","Februar","Mart","April","Maj","Juni",
+	"Juli","August","Septembar","Oktobar","Novembar","Decembar" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maj","Jun",
+	"Jul","Aug","Sep","Okt","Nov","Dec" ],
+	dayNames: [ "Nedelja","Ponedeljak","Utorak","Srijeda","Četvrtak","Petak","Subota" ],
+	dayNamesShort: [ "Ned","Pon","Uto","Sri","Čet","Pet","Sub" ],
+	dayNamesMin: [ "Ne","Po","Ut","Sr","Če","Pe","Su" ],
+	weekHeader: "Wk",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.bs );
+
+return datepicker.regional.bs;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ca.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ca.js
@@ -1,0 +1,37 @@
+/* Inicialització en català per a l'extensió 'UI date picker' per jQuery. */
+/* Writers: (joan.leon@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ca = {
+	closeText: "Tanca",
+	prevText: "Anterior",
+	nextText: "Següent",
+	currentText: "Avui",
+	monthNames: [ "gener","febrer","març","abril","maig","juny",
+	"juliol","agost","setembre","octubre","novembre","desembre" ],
+	monthNamesShort: [ "gen","feb","març","abr","maig","juny",
+	"jul","ag","set","oct","nov","des" ],
+	dayNames: [ "diumenge","dilluns","dimarts","dimecres","dijous","divendres","dissabte" ],
+	dayNamesShort: [ "dg","dl","dt","dc","dj","dv","ds" ],
+	dayNamesMin: [ "dg","dl","dt","dc","dj","dv","ds" ],
+	weekHeader: "Set",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ca );
+
+return datepicker.regional.ca;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-cs.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-cs.js
@@ -1,0 +1,37 @@
+/* Czech initialisation for the jQuery UI date picker plugin. */
+/* Written by Tomas Muller (tomas@tomas-muller.net). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.cs = {
+	closeText: "Zavřít",
+	prevText: "&#x3C;Dříve",
+	nextText: "Později&#x3E;",
+	currentText: "Nyní",
+	monthNames: [ "leden","únor","březen","duben","květen","červen",
+	"červenec","srpen","září","říjen","listopad","prosinec" ],
+	monthNamesShort: [ "led","úno","bře","dub","kvě","čer",
+	"čvc","srp","zář","říj","lis","pro" ],
+	dayNames: [ "neděle", "pondělí", "úterý", "středa", "čtvrtek", "pátek", "sobota" ],
+	dayNamesShort: [ "ne", "po", "út", "st", "čt", "pá", "so" ],
+	dayNamesMin: [ "ne","po","út","st","čt","pá","so" ],
+	weekHeader: "Týd",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.cs );
+
+return datepicker.regional.cs;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-cy-GB.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-cy-GB.js
@@ -1,0 +1,45 @@
+/* Welsh/UK initialisation for the jQuery UI date picker plugin. */
+/* Written by William Griffiths. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "cy-GB" ] = {
+	closeText: "Done",
+	prevText: "Prev",
+	nextText: "Next",
+	currentText: "Today",
+	monthNames: [ "Ionawr","Chwefror","Mawrth","Ebrill","Mai","Mehefin",
+	"Gorffennaf","Awst","Medi","Hydref","Tachwedd","Rhagfyr" ],
+	monthNamesShort: [ "Ion", "Chw", "Maw", "Ebr", "Mai", "Meh",
+	"Gor", "Aws", "Med", "Hyd", "Tac", "Rha" ],
+	dayNames: [
+		"Dydd Sul",
+		"Dydd Llun",
+		"Dydd Mawrth",
+		"Dydd Mercher",
+		"Dydd Iau",
+		"Dydd Gwener",
+		"Dydd Sadwrn"
+	],
+	dayNamesShort: [ "Sul", "Llu", "Maw", "Mer", "Iau", "Gwe", "Sad" ],
+	dayNamesMin: [ "Su","Ll","Ma","Me","Ia","Gw","Sa" ],
+	weekHeader: "Wy",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "cy-GB" ] );
+
+return datepicker.regional[ "cy-GB" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-da.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-da.js
@@ -1,0 +1,37 @@
+/* Danish initialisation for the jQuery UI date picker plugin. */
+/* Written by Jan Christensen ( deletestuff@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.da = {
+	closeText: "Luk",
+	prevText: "&#x3C;Forrige",
+	nextText: "Næste&#x3E;",
+	currentText: "Idag",
+	monthNames: [ "Januar","Februar","Marts","April","Maj","Juni",
+	"Juli","August","September","Oktober","November","December" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maj","Jun",
+	"Jul","Aug","Sep","Okt","Nov","Dec" ],
+	dayNames: [ "Søndag","Mandag","Tirsdag","Onsdag","Torsdag","Fredag","Lørdag" ],
+	dayNamesShort: [ "Søn","Man","Tir","Ons","Tor","Fre","Lør" ],
+	dayNamesMin: [ "Sø","Ma","Ti","On","To","Fr","Lø" ],
+	weekHeader: "Uge",
+	dateFormat: "dd-mm-yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.da );
+
+return datepicker.regional.da;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-de.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-de.js
@@ -1,0 +1,37 @@
+/* German initialisation for the jQuery UI date picker plugin. */
+/* Written by Milian Wolff (mail@milianw.de). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.de = {
+	closeText: "Schließen",
+	prevText: "&#x3C;Zurück",
+	nextText: "Vor&#x3E;",
+	currentText: "Heute",
+	monthNames: [ "Januar","Februar","März","April","Mai","Juni",
+	"Juli","August","September","Oktober","November","Dezember" ],
+	monthNamesShort: [ "Jan","Feb","Mär","Apr","Mai","Jun",
+	"Jul","Aug","Sep","Okt","Nov","Dez" ],
+	dayNames: [ "Sonntag","Montag","Dienstag","Mittwoch","Donnerstag","Freitag","Samstag" ],
+	dayNamesShort: [ "So","Mo","Di","Mi","Do","Fr","Sa" ],
+	dayNamesMin: [ "So","Mo","Di","Mi","Do","Fr","Sa" ],
+	weekHeader: "KW",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.de );
+
+return datepicker.regional.de;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-el.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-el.js
@@ -1,0 +1,37 @@
+/* Greek (el) initialisation for the jQuery UI date picker plugin. */
+/* Written by Alex Cicovic (http://www.alexcicovic.com) */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.el = {
+	closeText: "Κλείσιμο",
+	prevText: "Προηγούμενος",
+	nextText: "Επόμενος",
+	currentText: "Σήμερα",
+	monthNames: [ "Ιανουάριος","Φεβρουάριος","Μάρτιος","Απρίλιος","Μάιος","Ιούνιος",
+	"Ιούλιος","Αύγουστος","Σεπτέμβριος","Οκτώβριος","Νοέμβριος","Δεκέμβριος" ],
+	monthNamesShort: [ "Ιαν","Φεβ","Μαρ","Απρ","Μαι","Ιουν",
+	"Ιουλ","Αυγ","Σεπ","Οκτ","Νοε","Δεκ" ],
+	dayNames: [ "Κυριακή","Δευτέρα","Τρίτη","Τετάρτη","Πέμπτη","Παρασκευή","Σάββατο" ],
+	dayNamesShort: [ "Κυρ","Δευ","Τρι","Τετ","Πεμ","Παρ","Σαβ" ],
+	dayNamesMin: [ "Κυ","Δε","Τρ","Τε","Πε","Πα","Σα" ],
+	weekHeader: "Εβδ",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.el );
+
+return datepicker.regional.el;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-en-AU.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-en-AU.js
@@ -1,0 +1,37 @@
+/* English/Australia initialisation for the jQuery UI date picker plugin. */
+/* Based on the en-GB initialisation. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "en-AU" ] = {
+	closeText: "Done",
+	prevText: "Prev",
+	nextText: "Next",
+	currentText: "Today",
+	monthNames: [ "January","February","March","April","May","June",
+	"July","August","September","October","November","December" ],
+	monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+	dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+	dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
+	dayNamesMin: [ "Su","Mo","Tu","We","Th","Fr","Sa" ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "en-AU" ] );
+
+return datepicker.regional[ "en-AU" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-en-GB.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-en-GB.js
@@ -1,0 +1,37 @@
+/* English/UK initialisation for the jQuery UI date picker plugin. */
+/* Written by Stuart. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "en-GB" ] = {
+	closeText: "Done",
+	prevText: "Prev",
+	nextText: "Next",
+	currentText: "Today",
+	monthNames: [ "January","February","March","April","May","June",
+	"July","August","September","October","November","December" ],
+	monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+	dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+	dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
+	dayNamesMin: [ "Su","Mo","Tu","We","Th","Fr","Sa" ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "en-GB" ] );
+
+return datepicker.regional[ "en-GB" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-en-NZ.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-en-NZ.js
@@ -1,0 +1,37 @@
+/* English/New Zealand initialisation for the jQuery UI date picker plugin. */
+/* Based on the en-GB initialisation. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "en-NZ" ] = {
+	closeText: "Done",
+	prevText: "Prev",
+	nextText: "Next",
+	currentText: "Today",
+	monthNames: [ "January","February","March","April","May","June",
+	"July","August","September","October","November","December" ],
+	monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+	dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+	dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
+	dayNamesMin: [ "Su","Mo","Tu","We","Th","Fr","Sa" ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "en-NZ" ] );
+
+return datepicker.regional[ "en-NZ" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-eo.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-eo.js
@@ -1,0 +1,37 @@
+/* Esperanto initialisation for the jQuery UI date picker plugin. */
+/* Written by Olivier M. (olivierweb@ifrance.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.eo = {
+	closeText: "Fermi",
+	prevText: "&#x3C;Anta",
+	nextText: "Sekv&#x3E;",
+	currentText: "Nuna",
+	monthNames: [ "Januaro","Februaro","Marto","Aprilo","Majo","Junio",
+	"Julio","Aŭgusto","Septembro","Oktobro","Novembro","Decembro" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maj","Jun",
+	"Jul","Aŭg","Sep","Okt","Nov","Dec" ],
+	dayNames: [ "Dimanĉo","Lundo","Mardo","Merkredo","Ĵaŭdo","Vendredo","Sabato" ],
+	dayNamesShort: [ "Dim","Lun","Mar","Mer","Ĵaŭ","Ven","Sab" ],
+	dayNamesMin: [ "Di","Lu","Ma","Me","Ĵa","Ve","Sa" ],
+	weekHeader: "Sb",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.eo );
+
+return datepicker.regional.eo;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-es.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-es.js
@@ -1,0 +1,37 @@
+/* Inicialización en español para la extensión 'UI date picker' para jQuery. */
+/* Traducido por Vester (xvester@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.es = {
+	closeText: "Cerrar",
+	prevText: "&#x3C;Ant",
+	nextText: "Sig&#x3E;",
+	currentText: "Hoy",
+	monthNames: [ "enero","febrero","marzo","abril","mayo","junio",
+	"julio","agosto","septiembre","octubre","noviembre","diciembre" ],
+	monthNamesShort: [ "ene","feb","mar","abr","may","jun",
+	"jul","ago","sep","oct","nov","dic" ],
+	dayNames: [ "domingo","lunes","martes","miércoles","jueves","viernes","sábado" ],
+	dayNamesShort: [ "dom","lun","mar","mié","jue","vie","sáb" ],
+	dayNamesMin: [ "D","L","M","X","J","V","S" ],
+	weekHeader: "Sm",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.es );
+
+return datepicker.regional.es;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-et.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-et.js
@@ -1,0 +1,45 @@
+/* Estonian initialisation for the jQuery UI date picker plugin. */
+/* Written by Mart Sõmermaa (mrts.pydev at gmail com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.et = {
+	closeText: "Sulge",
+	prevText: "Eelnev",
+	nextText: "Järgnev",
+	currentText: "Täna",
+	monthNames: [ "Jaanuar","Veebruar","Märts","Aprill","Mai","Juuni",
+	"Juuli","August","September","Oktoober","November","Detsember" ],
+	monthNamesShort: [ "Jaan", "Veebr", "Märts", "Apr", "Mai", "Juuni",
+	"Juuli", "Aug", "Sept", "Okt", "Nov", "Dets" ],
+	dayNames: [
+		"Pühapäev",
+		"Esmaspäev",
+		"Teisipäev",
+		"Kolmapäev",
+		"Neljapäev",
+		"Reede",
+		"Laupäev"
+	],
+	dayNamesShort: [ "Pühap", "Esmasp", "Teisip", "Kolmap", "Neljap", "Reede", "Laup" ],
+	dayNamesMin: [ "P","E","T","K","N","R","L" ],
+	weekHeader: "näd",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.et );
+
+return datepicker.regional.et;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-eu.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-eu.js
@@ -1,0 +1,36 @@
+/* Karrikas-ek itzulia (karrikas@karrikas.com) */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.eu = {
+	closeText: "Egina",
+	prevText: "&#x3C;Aur",
+	nextText: "Hur&#x3E;",
+	currentText: "Gaur",
+	monthNames: [ "urtarrila","otsaila","martxoa","apirila","maiatza","ekaina",
+		"uztaila","abuztua","iraila","urria","azaroa","abendua" ],
+	monthNamesShort: [ "urt.","ots.","mar.","api.","mai.","eka.",
+		"uzt.","abu.","ira.","urr.","aza.","abe." ],
+	dayNames: [ "igandea","astelehena","asteartea","asteazkena","osteguna","ostirala","larunbata" ],
+	dayNamesShort: [ "ig.","al.","ar.","az.","og.","ol.","lr." ],
+	dayNamesMin: [ "ig","al","ar","az","og","ol","lr" ],
+	weekHeader: "As",
+	dateFormat: "yy-mm-dd",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.eu );
+
+return datepicker.regional.eu;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fa.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fa.js
@@ -1,0 +1,73 @@
+/* Persian (Farsi) Translation for the jQuery UI date picker plugin. */
+/* Javad Mowlanezhad -- jmowla@gmail.com */
+/* Jalali calendar should supported soon! (Its implemented but I have to test it) */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.fa = {
+	closeText: "بستن",
+	prevText: "&#x3C;قبلی",
+	nextText: "بعدی&#x3E;",
+	currentText: "امروز",
+	monthNames: [
+		"ژانویه",
+		"فوریه",
+		"مارس",
+		"آوریل",
+		"مه",
+		"ژوئن",
+		"ژوئیه",
+		"اوت",
+		"سپتامبر",
+		"اکتبر",
+		"نوامبر",
+		"دسامبر"
+	],
+	monthNamesShort: [ "1","2","3","4","5","6","7","8","9","10","11","12" ],
+	dayNames: [
+		"يکشنبه",
+		"دوشنبه",
+		"سه‌شنبه",
+		"چهارشنبه",
+		"پنجشنبه",
+		"جمعه",
+		"شنبه"
+	],
+	dayNamesShort: [
+		"ی",
+		"د",
+		"س",
+		"چ",
+		"پ",
+		"ج",
+		"ش"
+	],
+	dayNamesMin: [
+		"ی",
+		"د",
+		"س",
+		"چ",
+		"پ",
+		"ج",
+		"ش"
+	],
+	weekHeader: "هف",
+	dateFormat: "yy/mm/dd",
+	firstDay: 6,
+	isRTL: true,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.fa );
+
+return datepicker.regional.fa;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fi.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fi.js
@@ -1,0 +1,37 @@
+/* Finnish initialisation for the jQuery UI date picker plugin. */
+/* Written by Harri Kilpiö (harrikilpio@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.fi = {
+	closeText: "Sulje",
+	prevText: "&#xAB;Edellinen",
+	nextText: "Seuraava&#xBB;",
+	currentText: "Tänään",
+	monthNames: [ "Tammikuu","Helmikuu","Maaliskuu","Huhtikuu","Toukokuu","Kesäkuu",
+	"Heinäkuu","Elokuu","Syyskuu","Lokakuu","Marraskuu","Joulukuu" ],
+	monthNamesShort: [ "Tammi","Helmi","Maalis","Huhti","Touko","Kesä",
+	"Heinä","Elo","Syys","Loka","Marras","Joulu" ],
+	dayNamesShort: [ "Su","Ma","Ti","Ke","To","Pe","La" ],
+	dayNames: [ "Sunnuntai","Maanantai","Tiistai","Keskiviikko","Torstai","Perjantai","Lauantai" ],
+	dayNamesMin: [ "Su","Ma","Ti","Ke","To","Pe","La" ],
+	weekHeader: "Vk",
+	dateFormat: "d.m.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.fi );
+
+return datepicker.regional.fi;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fo.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fo.js
@@ -1,0 +1,45 @@
+/* Faroese initialisation for the jQuery UI date picker plugin */
+/* Written by Sverri Mohr Olsen, sverrimo@gmail.com */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.fo = {
+	closeText: "Lat aftur",
+	prevText: "&#x3C;Fyrra",
+	nextText: "Næsta&#x3E;",
+	currentText: "Í dag",
+	monthNames: [ "Januar","Februar","Mars","Apríl","Mei","Juni",
+	"Juli","August","September","Oktober","November","Desember" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Mei","Jun",
+	"Jul","Aug","Sep","Okt","Nov","Des" ],
+	dayNames: [
+		"Sunnudagur",
+		"Mánadagur",
+		"Týsdagur",
+		"Mikudagur",
+		"Hósdagur",
+		"Fríggjadagur",
+		"Leyardagur"
+	],
+	dayNamesShort: [ "Sun","Mán","Týs","Mik","Hós","Frí","Ley" ],
+	dayNamesMin: [ "Su","Má","Tý","Mi","Hó","Fr","Le" ],
+	weekHeader: "Vk",
+	dateFormat: "dd-mm-yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.fo );
+
+return datepicker.regional.fo;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fr-CA.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fr-CA.js
@@ -1,0 +1,37 @@
+/* Canadian-French initialisation for the jQuery UI date picker plugin. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "fr-CA" ] = {
+	closeText: "Fermer",
+	prevText: "Précédent",
+	nextText: "Suivant",
+	currentText: "Aujourd'hui",
+	monthNames: [ "janvier", "février", "mars", "avril", "mai", "juin",
+		"juillet", "août", "septembre", "octobre", "novembre", "décembre" ],
+	monthNamesShort: [ "janv.", "févr.", "mars", "avril", "mai", "juin",
+		"juil.", "août", "sept.", "oct.", "nov.", "déc." ],
+	dayNames: [ "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi" ],
+	dayNamesShort: [ "dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam." ],
+	dayNamesMin: [ "D", "L", "M", "M", "J", "V", "S" ],
+	weekHeader: "Sem.",
+	dateFormat: "yy-mm-dd",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: ""
+};
+datepicker.setDefaults( datepicker.regional[ "fr-CA" ] );
+
+return datepicker.regional[ "fr-CA" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fr-CH.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fr-CH.js
@@ -1,0 +1,37 @@
+/* Swiss-French initialisation for the jQuery UI date picker plugin. */
+/* Written Martin Voelkle (martin.voelkle@e-tc.ch). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "fr-CH" ] = {
+	closeText: "Fermer",
+	prevText: "&#x3C;Préc",
+	nextText: "Suiv&#x3E;",
+	currentText: "Courant",
+	monthNames: [ "janvier", "février", "mars", "avril", "mai", "juin",
+		"juillet", "août", "septembre", "octobre", "novembre", "décembre" ],
+	monthNamesShort: [ "janv.", "févr.", "mars", "avril", "mai", "juin",
+		"juil.", "août", "sept.", "oct.", "nov.", "déc." ],
+	dayNames: [ "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi" ],
+	dayNamesShort: [ "dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam." ],
+	dayNamesMin: [ "D", "L", "M", "M", "J", "V", "S" ],
+	weekHeader: "Sm",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "fr-CH" ] );
+
+return datepicker.regional[ "fr-CH" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fr.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-fr.js
@@ -1,0 +1,39 @@
+/* French initialisation for the jQuery UI date picker plugin. */
+/* Written by Keith Wood (kbwood{at}iinet.com.au),
+			  Stéphane Nahmani (sholby@sholby.net),
+			  Stéphane Raimbault <stephane.raimbault@gmail.com> */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.fr = {
+	closeText: "Fermer",
+	prevText: "Précédent",
+	nextText: "Suivant",
+	currentText: "Aujourd'hui",
+	monthNames: [ "janvier", "février", "mars", "avril", "mai", "juin",
+		"juillet", "août", "septembre", "octobre", "novembre", "décembre" ],
+	monthNamesShort: [ "janv.", "févr.", "mars", "avr.", "mai", "juin",
+		"juil.", "août", "sept.", "oct.", "nov.", "déc." ],
+	dayNames: [ "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi" ],
+	dayNamesShort: [ "dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam." ],
+	dayNamesMin: [ "D","L","M","M","J","V","S" ],
+	weekHeader: "Sem.",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.fr );
+
+return datepicker.regional.fr;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-gl.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-gl.js
@@ -1,0 +1,37 @@
+/* Galician localization for 'UI date picker' jQuery extension. */
+/* Translated by Jorge Barreiro <yortx.barry@gmail.com>. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.gl = {
+	closeText: "Pechar",
+	prevText: "&#x3C;Ant",
+	nextText: "Seg&#x3E;",
+	currentText: "Hoxe",
+	monthNames: [ "Xaneiro","Febreiro","Marzo","Abril","Maio","Xuño",
+	"Xullo","Agosto","Setembro","Outubro","Novembro","Decembro" ],
+	monthNamesShort: [ "Xan","Feb","Mar","Abr","Mai","Xuñ",
+	"Xul","Ago","Set","Out","Nov","Dec" ],
+	dayNames: [ "Domingo","Luns","Martes","Mércores","Xoves","Venres","Sábado" ],
+	dayNamesShort: [ "Dom","Lun","Mar","Mér","Xov","Ven","Sáb" ],
+	dayNamesMin: [ "Do","Lu","Ma","Mé","Xo","Ve","Sá" ],
+	weekHeader: "Sm",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.gl );
+
+return datepicker.regional.gl;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-he.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-he.js
@@ -1,0 +1,37 @@
+/* Hebrew initialisation for the UI Datepicker extension. */
+/* Written by Amir Hardon (ahardon at gmail dot com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.he = {
+	closeText: "סגור",
+	prevText: "&#x3C;הקודם",
+	nextText: "הבא&#x3E;",
+	currentText: "היום",
+	monthNames: [ "ינואר","פברואר","מרץ","אפריל","מאי","יוני",
+	"יולי","אוגוסט","ספטמבר","אוקטובר","נובמבר","דצמבר" ],
+	monthNamesShort: [ "ינו","פבר","מרץ","אפר","מאי","יוני",
+	"יולי","אוג","ספט","אוק","נוב","דצמ" ],
+	dayNames: [ "ראשון","שני","שלישי","רביעי","חמישי","שישי","שבת" ],
+	dayNamesShort: [ "א'","ב'","ג'","ד'","ה'","ו'","שבת" ],
+	dayNamesMin: [ "א'","ב'","ג'","ד'","ה'","ו'","שבת" ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: true,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.he );
+
+return datepicker.regional.he;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hi.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hi.js
@@ -1,0 +1,37 @@
+/* Hindi initialisation for the jQuery UI date picker plugin. */
+/* Written by Michael Dawart. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.hi = {
+	closeText: "बंद",
+	prevText: "पिछला",
+	nextText: "अगला",
+	currentText: "आज",
+	monthNames: [ "जनवरी ","फरवरी","मार्च","अप्रेल","मई","जून",
+	"जूलाई","अगस्त ","सितम्बर","अक्टूबर","नवम्बर","दिसम्बर" ],
+	monthNamesShort: [ "जन", "फर", "मार्च", "अप्रेल", "मई", "जून",
+	"जूलाई", "अग", "सित", "अक्ट", "नव", "दि" ],
+	dayNames: [ "रविवार", "सोमवार", "मंगलवार", "बुधवार", "गुरुवार", "शुक्रवार", "शनिवार" ],
+	dayNamesShort: [ "रवि", "सोम", "मंगल", "बुध", "गुरु", "शुक्र", "शनि" ],
+	dayNamesMin: [ "रवि", "सोम", "मंगल", "बुध", "गुरु", "शुक्र", "शनि" ],
+	weekHeader: "हफ्ता",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.hi );
+
+return datepicker.regional.hi;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hr.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hr.js
@@ -1,0 +1,37 @@
+/* Croatian i18n for the jQuery UI date picker plugin. */
+/* Written by Vjekoslav Nesek. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.hr = {
+	closeText: "Zatvori",
+	prevText: "&#x3C;",
+	nextText: "&#x3E;",
+	currentText: "Danas",
+	monthNames: [ "Siječanj","Veljača","Ožujak","Travanj","Svibanj","Lipanj",
+	"Srpanj","Kolovoz","Rujan","Listopad","Studeni","Prosinac" ],
+	monthNamesShort: [ "Sij","Velj","Ožu","Tra","Svi","Lip",
+	"Srp","Kol","Ruj","Lis","Stu","Pro" ],
+	dayNames: [ "Nedjelja","Ponedjeljak","Utorak","Srijeda","Četvrtak","Petak","Subota" ],
+	dayNamesShort: [ "Ned","Pon","Uto","Sri","Čet","Pet","Sub" ],
+	dayNamesMin: [ "Ne","Po","Ut","Sr","Če","Pe","Su" ],
+	weekHeader: "Tje",
+	dateFormat: "dd.mm.yy.",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.hr );
+
+return datepicker.regional.hr;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hu.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hu.js
@@ -1,0 +1,36 @@
+/* Hungarian initialisation for the jQuery UI date picker plugin. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.hu = {
+	closeText: "bezár",
+	prevText: "vissza",
+	nextText: "előre",
+	currentText: "ma",
+	monthNames: [ "Január", "Február", "Március", "Április", "Május", "Június",
+	"Július", "Augusztus", "Szeptember", "Október", "November", "December" ],
+	monthNamesShort: [ "Jan", "Feb", "Már", "Ápr", "Máj", "Jún",
+	"Júl", "Aug", "Szep", "Okt", "Nov", "Dec" ],
+	dayNames: [ "Vasárnap", "Hétfő", "Kedd", "Szerda", "Csütörtök", "Péntek", "Szombat" ],
+	dayNamesShort: [ "Vas", "Hét", "Ked", "Sze", "Csü", "Pén", "Szo" ],
+	dayNamesMin: [ "V", "H", "K", "Sze", "Cs", "P", "Szo" ],
+	weekHeader: "Hét",
+	dateFormat: "yy.mm.dd.",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: true,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.hu );
+
+return datepicker.regional.hu;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hy.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-hy.js
@@ -1,0 +1,37 @@
+/* Armenian(UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Levon Zakaryan (levon.zakaryan@gmail.com)*/
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.hy = {
+	closeText: "Փակել",
+	prevText: "&#x3C;Նախ.",
+	nextText: "Հաջ.&#x3E;",
+	currentText: "Այսօր",
+	monthNames: [ "Հունվար","Փետրվար","Մարտ","Ապրիլ","Մայիս","Հունիս",
+	"Հուլիս","Օգոստոս","Սեպտեմբեր","Հոկտեմբեր","Նոյեմբեր","Դեկտեմբեր" ],
+	monthNamesShort: [ "Հունվ","Փետր","Մարտ","Ապր","Մայիս","Հունիս",
+	"Հուլ","Օգս","Սեպ","Հոկ","Նոյ","Դեկ" ],
+	dayNames: [ "կիրակի","եկուշաբթի","երեքշաբթի","չորեքշաբթի","հինգշաբթի","ուրբաթ","շաբաթ" ],
+	dayNamesShort: [ "կիր","երկ","երք","չրք","հնգ","ուրբ","շբթ" ],
+	dayNamesMin: [ "կիր","երկ","երք","չրք","հնգ","ուրբ","շբթ" ],
+	weekHeader: "ՇԲՏ",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.hy );
+
+return datepicker.regional.hy;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-id.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-id.js
@@ -1,0 +1,37 @@
+/* Indonesian initialisation for the jQuery UI date picker plugin. */
+/* Written by Deden Fathurahman (dedenf@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.id = {
+	closeText: "Tutup",
+	prevText: "&#x3C;mundur",
+	nextText: "maju&#x3E;",
+	currentText: "hari ini",
+	monthNames: [ "Januari","Februari","Maret","April","Mei","Juni",
+	"Juli","Agustus","September","Oktober","Nopember","Desember" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Mei","Jun",
+	"Jul","Agus","Sep","Okt","Nop","Des" ],
+	dayNames: [ "Minggu","Senin","Selasa","Rabu","Kamis","Jumat","Sabtu" ],
+	dayNamesShort: [ "Min","Sen","Sel","Rab","kam","Jum","Sab" ],
+	dayNamesMin: [ "Mg","Sn","Sl","Rb","Km","jm","Sb" ],
+	weekHeader: "Mg",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.id );
+
+return datepicker.regional.id;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-in.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-in.js
@@ -1,0 +1,37 @@
+/* Indonesian initialisation for the jQuery UI date picker plugin. */
+/* Written by Deden Fathurahman (dedenf@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.id = {
+	closeText: "Tutup",
+	prevText: "&#x3C;mundur",
+	nextText: "maju&#x3E;",
+	currentText: "hari ini",
+	monthNames: [ "Januari","Februari","Maret","April","Mei","Juni",
+	"Juli","Agustus","September","Oktober","Nopember","Desember" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Mei","Jun",
+	"Jul","Agus","Sep","Okt","Nop","Des" ],
+	dayNames: [ "Minggu","Senin","Selasa","Rabu","Kamis","Jumat","Sabtu" ],
+	dayNamesShort: [ "Min","Sen","Sel","Rab","kam","Jum","Sab" ],
+	dayNamesMin: [ "Mg","Sn","Sl","Rb","Km","jm","Sb" ],
+	weekHeader: "Mg",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.id );
+
+return datepicker.regional.id;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-is.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-is.js
@@ -1,0 +1,45 @@
+/* Icelandic initialisation for the jQuery UI date picker plugin. */
+/* Written by Haukur H. Thorsson (haukur@eskill.is). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.is = {
+	closeText: "Loka",
+	prevText: "&#x3C; Fyrri",
+	nextText: "Næsti &#x3E;",
+	currentText: "Í dag",
+	monthNames: [ "Janúar","Febrúar","Mars","Apríl","Maí","Júní",
+	"Júlí","Ágúst","September","Október","Nóvember","Desember" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maí","Jún",
+	"Júl","Ágú","Sep","Okt","Nóv","Des" ],
+	dayNames: [
+		"Sunnudagur",
+		"Mánudagur",
+		"Þriðjudagur",
+		"Miðvikudagur",
+		"Fimmtudagur",
+		"Föstudagur",
+		"Laugardagur"
+	],
+	dayNamesShort: [ "Sun","Mán","Þri","Mið","Fim","Fös","Lau" ],
+	dayNamesMin: [ "Su","Má","Þr","Mi","Fi","Fö","La" ],
+	weekHeader: "Vika",
+	dateFormat: "dd.mm.yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.is );
+
+return datepicker.regional.is;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-it-CH.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-it-CH.js
@@ -1,0 +1,37 @@
+/* Italian initialisation for the jQuery UI date picker plugin. */
+/* Written by Antonello Pasella (antonello.pasella@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "it-CH" ] = {
+	closeText: "Chiudi",
+	prevText: "&#x3C;Prec",
+	nextText: "Succ&#x3E;",
+	currentText: "Oggi",
+	monthNames: [ "Gennaio","Febbraio","Marzo","Aprile","Maggio","Giugno",
+		"Luglio","Agosto","Settembre","Ottobre","Novembre","Dicembre" ],
+	monthNamesShort: [ "Gen","Feb","Mar","Apr","Mag","Giu",
+		"Lug","Ago","Set","Ott","Nov","Dic" ],
+	dayNames: [ "Domenica","Lunedì","Martedì","Mercoledì","Giovedì","Venerdì","Sabato" ],
+	dayNamesShort: [ "Dom","Lun","Mar","Mer","Gio","Ven","Sab" ],
+	dayNamesMin: [ "Do","Lu","Ma","Me","Gi","Ve","Sa" ],
+	weekHeader: "Sm",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "it-CH" ] );
+
+return datepicker.regional[ "it-CH" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-it.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-it.js
@@ -1,0 +1,37 @@
+/* Italian initialisation for the jQuery UI date picker plugin. */
+/* Written by Antonello Pasella (antonello.pasella@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.it = {
+	closeText: "Chiudi",
+	prevText: "&#x3C;Prec",
+	nextText: "Succ&#x3E;",
+	currentText: "Oggi",
+	monthNames: [ "Gennaio","Febbraio","Marzo","Aprile","Maggio","Giugno",
+		"Luglio","Agosto","Settembre","Ottobre","Novembre","Dicembre" ],
+	monthNamesShort: [ "Gen","Feb","Mar","Apr","Mag","Giu",
+		"Lug","Ago","Set","Ott","Nov","Dic" ],
+	dayNames: [ "Domenica","Lunedì","Martedì","Mercoledì","Giovedì","Venerdì","Sabato" ],
+	dayNamesShort: [ "Dom","Lun","Mar","Mer","Gio","Ven","Sab" ],
+	dayNamesMin: [ "Do","Lu","Ma","Me","Gi","Ve","Sa" ],
+	weekHeader: "Sm",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.it );
+
+return datepicker.regional.it;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-iw.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-iw.js
@@ -1,0 +1,37 @@
+/* Hebrew initialisation for the UI Datepicker extension. */
+/* Written by Amir Hardon (ahardon at gmail dot com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.he = {
+	closeText: "סגור",
+	prevText: "&#x3C;הקודם",
+	nextText: "הבא&#x3E;",
+	currentText: "היום",
+	monthNames: [ "ינואר","פברואר","מרץ","אפריל","מאי","יוני",
+	"יולי","אוגוסט","ספטמבר","אוקטובר","נובמבר","דצמבר" ],
+	monthNamesShort: [ "ינו","פבר","מרץ","אפר","מאי","יוני",
+	"יולי","אוג","ספט","אוק","נוב","דצמ" ],
+	dayNames: [ "ראשון","שני","שלישי","רביעי","חמישי","שישי","שבת" ],
+	dayNamesShort: [ "א'","ב'","ג'","ד'","ה'","ו'","שבת" ],
+	dayNamesMin: [ "א'","ב'","ג'","ד'","ה'","ו'","שבת" ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: true,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.he );
+
+return datepicker.regional.he;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ja.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ja.js
@@ -1,0 +1,37 @@
+/* Japanese initialisation for the jQuery UI date picker plugin. */
+/* Written by Kentaro SATO (kentaro@ranvis.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ja = {
+	closeText: "閉じる",
+	prevText: "&#x3C;前",
+	nextText: "次&#x3E;",
+	currentText: "今日",
+	monthNames: [ "1月","2月","3月","4月","5月","6月",
+	"7月","8月","9月","10月","11月","12月" ],
+	monthNamesShort: [ "1月","2月","3月","4月","5月","6月",
+	"7月","8月","9月","10月","11月","12月" ],
+	dayNames: [ "日曜日","月曜日","火曜日","水曜日","木曜日","金曜日","土曜日" ],
+	dayNamesShort: [ "日","月","火","水","木","金","土" ],
+	dayNamesMin: [ "日","月","火","水","木","金","土" ],
+	weekHeader: "週",
+	dateFormat: "yy/mm/dd",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: true,
+	yearSuffix: "年" };
+datepicker.setDefaults( datepicker.regional.ja );
+
+return datepicker.regional.ja;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ka.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ka.js
@@ -1,0 +1,48 @@
+/* Georgian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Lado Lomidze (lado.lomidze@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ka = {
+	closeText: "დახურვა",
+	prevText: "&#x3c; წინა",
+	nextText: "შემდეგი &#x3e;",
+	currentText: "დღეს",
+	monthNames: [
+		"იანვარი",
+		"თებერვალი",
+		"მარტი",
+		"აპრილი",
+		"მაისი",
+		"ივნისი",
+		"ივლისი",
+		"აგვისტო",
+		"სექტემბერი",
+		"ოქტომბერი",
+		"ნოემბერი",
+		"დეკემბერი"
+	],
+	monthNamesShort: [ "იან","თებ","მარ","აპრ","მაი","ივნ", "ივლ","აგვ","სექ","ოქტ","ნოე","დეკ" ],
+	dayNames: [ "კვირა","ორშაბათი","სამშაბათი","ოთხშაბათი","ხუთშაბათი","პარასკევი","შაბათი" ],
+	dayNamesShort: [ "კვ","ორშ","სამ","ოთხ","ხუთ","პარ","შაბ" ],
+	dayNamesMin: [ "კვ","ორშ","სამ","ოთხ","ხუთ","პარ","შაბ" ],
+	weekHeader: "კვირა",
+	dateFormat: "dd-mm-yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ka );
+
+return datepicker.regional.ka;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-kk.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-kk.js
@@ -1,0 +1,37 @@
+/* Kazakh (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Dmitriy Karasyov (dmitriy.karasyov@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.kk = {
+	closeText: "Жабу",
+	prevText: "&#x3C;Алдыңғы",
+	nextText: "Келесі&#x3E;",
+	currentText: "Бүгін",
+	monthNames: [ "Қаңтар","Ақпан","Наурыз","Сәуір","Мамыр","Маусым",
+	"Шілде","Тамыз","Қыркүйек","Қазан","Қараша","Желтоқсан" ],
+	monthNamesShort: [ "Қаң","Ақп","Нау","Сәу","Мам","Мау",
+	"Шіл","Там","Қыр","Қаз","Қар","Жел" ],
+	dayNames: [ "Жексенбі","Дүйсенбі","Сейсенбі","Сәрсенбі","Бейсенбі","Жұма","Сенбі" ],
+	dayNamesShort: [ "жкс","дсн","ссн","срс","бсн","жма","снб" ],
+	dayNamesMin: [ "Жк","Дс","Сс","Ср","Бс","Жм","Сн" ],
+	weekHeader: "Не",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.kk );
+
+return datepicker.regional.kk;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-km.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-km.js
@@ -1,0 +1,37 @@
+/* Khmer initialisation for the jQuery calendar extension. */
+/* Written by Chandara Om (chandara.teacher@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.km = {
+	closeText: "ធ្វើ​រួច",
+	prevText: "មុន",
+	nextText: "បន្ទាប់",
+	currentText: "ថ្ងៃ​នេះ",
+	monthNames: [ "មករា","កុម្ភៈ","មីនា","មេសា","ឧសភា","មិថុនា",
+	"កក្កដា","សីហា","កញ្ញា","តុលា","វិច្ឆិកា","ធ្នូ" ],
+	monthNamesShort: [ "មករា","កុម្ភៈ","មីនា","មេសា","ឧសភា","មិថុនា",
+	"កក្កដា","សីហា","កញ្ញា","តុលា","វិច្ឆិកា","ធ្នូ" ],
+	dayNames: [ "អាទិត្យ", "ចន្ទ", "អង្គារ", "ពុធ", "ព្រហស្បតិ៍", "សុក្រ", "សៅរ៍" ],
+	dayNamesShort: [ "អា", "ច", "អ", "ពុ", "ព្រហ", "សុ", "សៅ" ],
+	dayNamesMin: [ "អា", "ច", "អ", "ពុ", "ព្រហ", "សុ", "សៅ" ],
+	weekHeader: "សប្ដាហ៍",
+	dateFormat: "dd-mm-yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.km );
+
+return datepicker.regional.km;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ko.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ko.js
@@ -1,0 +1,37 @@
+/* Korean initialisation for the jQuery calendar extension. */
+/* Written by DaeKwon Kang (ncrash.dk@gmail.com), Edited by Genie and Myeongjin Lee. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ko = {
+	closeText: "닫기",
+	prevText: "이전달",
+	nextText: "다음달",
+	currentText: "오늘",
+	monthNames: [ "1월","2월","3월","4월","5월","6월",
+	"7월","8월","9월","10월","11월","12월" ],
+	monthNamesShort: [ "1월","2월","3월","4월","5월","6월",
+	"7월","8월","9월","10월","11월","12월" ],
+	dayNames: [ "일요일","월요일","화요일","수요일","목요일","금요일","토요일" ],
+	dayNamesShort: [ "일","월","화","수","목","금","토" ],
+	dayNamesMin: [ "일","월","화","수","목","금","토" ],
+	weekHeader: "주",
+	dateFormat: "yy. m. d.",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: true,
+	yearSuffix: "년" };
+datepicker.setDefaults( datepicker.regional.ko );
+
+return datepicker.regional.ko;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ky.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ky.js
@@ -1,0 +1,38 @@
+/* Kyrgyz (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Sergey Kartashov (ebishkek@yandex.ru). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ky = {
+	closeText: "Жабуу",
+	prevText: "&#x3c;Мур",
+	nextText: "Кий&#x3e;",
+	currentText: "Бүгүн",
+	monthNames: [ "Январь","Февраль","Март","Апрель","Май","Июнь",
+	"Июль","Август","Сентябрь","Октябрь","Ноябрь","Декабрь" ],
+	monthNamesShort: [ "Янв","Фев","Мар","Апр","Май","Июн",
+	"Июл","Авг","Сен","Окт","Ноя","Дек" ],
+	dayNames: [ "жекшемби", "дүйшөмбү", "шейшемби", "шаршемби", "бейшемби", "жума", "ишемби" ],
+	dayNamesShort: [ "жек", "дүй", "шей", "шар", "бей", "жум", "ише" ],
+	dayNamesMin: [ "Жк","Дш","Шш","Шр","Бш","Жм","Иш" ],
+	weekHeader: "Жум",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: ""
+};
+datepicker.setDefaults( datepicker.regional.ky );
+
+return datepicker.regional.ky;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-kz.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-kz.js
@@ -1,0 +1,37 @@
+/* Kazakh (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Dmitriy Karasyov (dmitriy.karasyov@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.kk = {
+	closeText: "Жабу",
+	prevText: "&#x3C;Алдыңғы",
+	nextText: "Келесі&#x3E;",
+	currentText: "Бүгін",
+	monthNames: [ "Қаңтар","Ақпан","Наурыз","Сәуір","Мамыр","Маусым",
+	"Шілде","Тамыз","Қыркүйек","Қазан","Қараша","Желтоқсан" ],
+	monthNamesShort: [ "Қаң","Ақп","Нау","Сәу","Мам","Мау",
+	"Шіл","Там","Қыр","Қаз","Қар","Жел" ],
+	dayNames: [ "Жексенбі","Дүйсенбі","Сейсенбі","Сәрсенбі","Бейсенбі","Жұма","Сенбі" ],
+	dayNamesShort: [ "жкс","дсн","ссн","срс","бсн","жма","снб" ],
+	dayNamesMin: [ "Жк","Дс","Сс","Ср","Бс","Жм","Сн" ],
+	weekHeader: "Не",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.kk );
+
+return datepicker.regional.kk;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-lb.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-lb.js
@@ -1,0 +1,45 @@
+/* Luxembourgish initialisation for the jQuery UI date picker plugin. */
+/* Written by Michel Weimerskirch <michel@weimerskirch.net> */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.lb = {
+	closeText: "Fäerdeg",
+	prevText: "Zréck",
+	nextText: "Weider",
+	currentText: "Haut",
+	monthNames: [ "Januar","Februar","Mäerz","Abrëll","Mee","Juni",
+	"Juli","August","September","Oktober","November","Dezember" ],
+	monthNamesShort: [ "Jan", "Feb", "Mäe", "Abr", "Mee", "Jun",
+	"Jul", "Aug", "Sep", "Okt", "Nov", "Dez" ],
+	dayNames: [
+		"Sonndeg",
+		"Méindeg",
+		"Dënschdeg",
+		"Mëttwoch",
+		"Donneschdeg",
+		"Freideg",
+		"Samschdeg"
+	],
+	dayNamesShort: [ "Son", "Méi", "Dën", "Mët", "Don", "Fre", "Sam" ],
+	dayNamesMin: [ "So","Mé","Dë","Më","Do","Fr","Sa" ],
+	weekHeader: "W",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.lb );
+
+return datepicker.regional.lb;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-lt.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-lt.js
@@ -1,0 +1,45 @@
+/* Lithuanian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* @author Arturas Paleicikas <arturas@avalon.lt> */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.lt = {
+	closeText: "Uždaryti",
+	prevText: "&#x3C;Atgal",
+	nextText: "Pirmyn&#x3E;",
+	currentText: "Šiandien",
+	monthNames: [ "Sausis","Vasaris","Kovas","Balandis","Gegužė","Birželis",
+	"Liepa","Rugpjūtis","Rugsėjis","Spalis","Lapkritis","Gruodis" ],
+	monthNamesShort: [ "Sau","Vas","Kov","Bal","Geg","Bir",
+	"Lie","Rugp","Rugs","Spa","Lap","Gru" ],
+	dayNames: [
+		"sekmadienis",
+		"pirmadienis",
+		"antradienis",
+		"trečiadienis",
+		"ketvirtadienis",
+		"penktadienis",
+		"šeštadienis"
+	],
+	dayNamesShort: [ "sek","pir","ant","tre","ket","pen","šeš" ],
+	dayNamesMin: [ "Se","Pr","An","Tr","Ke","Pe","Še" ],
+	weekHeader: "SAV",
+	dateFormat: "yy-mm-dd",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: true,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.lt );
+
+return datepicker.regional.lt;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-lv.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-lv.js
@@ -1,0 +1,45 @@
+/* Latvian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* @author Arturas Paleicikas <arturas.paleicikas@metasite.net> */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.lv = {
+	closeText: "Aizvērt",
+	prevText: "Iepr.",
+	nextText: "Nāk.",
+	currentText: "Šodien",
+	monthNames: [ "Janvāris","Februāris","Marts","Aprīlis","Maijs","Jūnijs",
+	"Jūlijs","Augusts","Septembris","Oktobris","Novembris","Decembris" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Mai","Jūn",
+	"Jūl","Aug","Sep","Okt","Nov","Dec" ],
+	dayNames: [
+		"svētdiena",
+		"pirmdiena",
+		"otrdiena",
+		"trešdiena",
+		"ceturtdiena",
+		"piektdiena",
+		"sestdiena"
+	],
+	dayNamesShort: [ "svt","prm","otr","tre","ctr","pkt","sst" ],
+	dayNamesMin: [ "Sv","Pr","Ot","Tr","Ct","Pk","Ss" ],
+	weekHeader: "Ned.",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.lv );
+
+return datepicker.regional.lv;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-mk.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-mk.js
@@ -1,0 +1,37 @@
+/* Macedonian i18n for the jQuery UI date picker plugin. */
+/* Written by Stojce Slavkovski. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.mk = {
+	closeText: "Затвори",
+	prevText: "&#x3C;",
+	nextText: "&#x3E;",
+	currentText: "Денес",
+	monthNames: [ "Јануари","Февруари","Март","Април","Мај","Јуни",
+	"Јули","Август","Септември","Октомври","Ноември","Декември" ],
+	monthNamesShort: [ "Јан","Фев","Мар","Апр","Мај","Јун",
+	"Јул","Авг","Сеп","Окт","Ное","Дек" ],
+	dayNames: [ "Недела","Понеделник","Вторник","Среда","Четврток","Петок","Сабота" ],
+	dayNamesShort: [ "Нед","Пон","Вто","Сре","Чет","Пет","Саб" ],
+	dayNamesMin: [ "Не","По","Вт","Ср","Че","Пе","Са" ],
+	weekHeader: "Сед",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.mk );
+
+return datepicker.regional.mk;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ml.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ml.js
@@ -1,0 +1,37 @@
+/* Malayalam (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Saji Nediyanchath (saji89@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ml = {
+	closeText: "ശരി",
+	prevText: "മുന്നത്തെ",
+	nextText: "അടുത്തത് ",
+	currentText: "ഇന്ന്",
+	monthNames: [ "ജനുവരി","ഫെബ്രുവരി","മാര്‍ച്ച്","ഏപ്രില്‍","മേയ്","ജൂണ്‍",
+	"ജൂലൈ","ആഗസ്റ്റ്","സെപ്റ്റംബര്‍","ഒക്ടോബര്‍","നവംബര്‍","ഡിസംബര്‍" ],
+	monthNamesShort: [ "ജനു", "ഫെബ്", "മാര്‍", "ഏപ്രി", "മേയ്", "ജൂണ്‍",
+	"ജൂലാ", "ആഗ", "സെപ്", "ഒക്ടോ", "നവം", "ഡിസ" ],
+	dayNames: [ "ഞായര്‍", "തിങ്കള്‍", "ചൊവ്വ", "ബുധന്‍", "വ്യാഴം", "വെള്ളി", "ശനി" ],
+	dayNamesShort: [ "ഞായ", "തിങ്ക", "ചൊവ്വ", "ബുധ", "വ്യാഴം", "വെള്ളി", "ശനി" ],
+	dayNamesMin: [ "ഞാ","തി","ചൊ","ബു","വ്യാ","വെ","ശ" ],
+	weekHeader: "ആ",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ml );
+
+return datepicker.regional.ml;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ms.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ms.js
@@ -1,0 +1,37 @@
+/* Malaysian initialisation for the jQuery UI date picker plugin. */
+/* Written by Mohd Nawawi Mohamad Jamili (nawawi@ronggeng.net). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ms = {
+	closeText: "Tutup",
+	prevText: "&#x3C;Sebelum",
+	nextText: "Selepas&#x3E;",
+	currentText: "hari ini",
+	monthNames: [ "Januari","Februari","Mac","April","Mei","Jun",
+	"Julai","Ogos","September","Oktober","November","Disember" ],
+	monthNamesShort: [ "Jan","Feb","Mac","Apr","Mei","Jun",
+	"Jul","Ogo","Sep","Okt","Nov","Dis" ],
+	dayNames: [ "Ahad","Isnin","Selasa","Rabu","Khamis","Jumaat","Sabtu" ],
+	dayNamesShort: [ "Aha","Isn","Sel","Rab","kha","Jum","Sab" ],
+	dayNamesMin: [ "Ah","Is","Se","Ra","Kh","Ju","Sa" ],
+	weekHeader: "Mg",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ms );
+
+return datepicker.regional.ms;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nb.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nb.js
@@ -1,0 +1,49 @@
+/* Norwegian Bokmål initialisation for the jQuery UI date picker plugin. */
+/* Written by Bjørn Johansen (post@bjornjohansen.no). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.nb = {
+	closeText: "Lukk",
+	prevText: "&#xAB;Forrige",
+	nextText: "Neste&#xBB;",
+	currentText: "I dag",
+	monthNames: [
+		"januar",
+		"februar",
+		"mars",
+		"april",
+		"mai",
+		"juni",
+		"juli",
+		"august",
+		"september",
+		"oktober",
+		"november",
+		"desember"
+	],
+	monthNamesShort: [ "jan","feb","mar","apr","mai","jun","jul","aug","sep","okt","nov","des" ],
+	dayNamesShort: [ "søn","man","tir","ons","tor","fre","lør" ],
+	dayNames: [ "søndag","mandag","tirsdag","onsdag","torsdag","fredag","lørdag" ],
+	dayNamesMin: [ "sø","ma","ti","on","to","fr","lø" ],
+	weekHeader: "Uke",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: ""
+};
+datepicker.setDefaults( datepicker.regional.nb );
+
+return datepicker.regional.nb;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nl-BE.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nl-BE.js
@@ -1,0 +1,37 @@
+/* Dutch (Belgium) initialisation for the jQuery UI date picker plugin. */
+/* David De Sloovere @DavidDeSloovere */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "nl-BE" ] = {
+	closeText: "Sluiten",
+	prevText: "←",
+	nextText: "→",
+	currentText: "Vandaag",
+	monthNames: [ "januari", "februari", "maart", "april", "mei", "juni",
+	"juli", "augustus", "september", "oktober", "november", "december" ],
+	monthNamesShort: [ "jan", "feb", "mrt", "apr", "mei", "jun",
+	"jul", "aug", "sep", "okt", "nov", "dec" ],
+	dayNames: [ "zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag" ],
+	dayNamesShort: [ "zon", "maa", "din", "woe", "don", "vri", "zat" ],
+	dayNamesMin: [ "zo", "ma", "di", "wo", "do", "vr", "za" ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "nl-BE" ] );
+
+return datepicker.regional[ "nl-BE" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nl.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nl.js
@@ -1,0 +1,37 @@
+/* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Mathias Bynens <http://mathiasbynens.be/> */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.nl = {
+	closeText: "Sluiten",
+	prevText: "←",
+	nextText: "→",
+	currentText: "Vandaag",
+	monthNames: [ "januari", "februari", "maart", "april", "mei", "juni",
+	"juli", "augustus", "september", "oktober", "november", "december" ],
+	monthNamesShort: [ "jan", "feb", "mrt", "apr", "mei", "jun",
+	"jul", "aug", "sep", "okt", "nov", "dec" ],
+	dayNames: [ "zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag" ],
+	dayNamesShort: [ "zon", "maa", "din", "woe", "don", "vri", "zat" ],
+	dayNamesMin: [ "zo", "ma", "di", "wo", "do", "vr", "za" ],
+	weekHeader: "Wk",
+	dateFormat: "dd-mm-yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.nl );
+
+return datepicker.regional.nl;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nn.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-nn.js
@@ -1,0 +1,49 @@
+/* Norwegian Nynorsk initialisation for the jQuery UI date picker plugin. */
+/* Written by Bjørn Johansen (post@bjornjohansen.no). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.nn = {
+	closeText: "Lukk",
+	prevText: "&#xAB;Førre",
+	nextText: "Neste&#xBB;",
+	currentText: "I dag",
+	monthNames: [
+		"januar",
+		"februar",
+		"mars",
+		"april",
+		"mai",
+		"juni",
+		"juli",
+		"august",
+		"september",
+		"oktober",
+		"november",
+		"desember"
+	],
+	monthNamesShort: [ "jan","feb","mar","apr","mai","jun","jul","aug","sep","okt","nov","des" ],
+	dayNamesShort: [ "sun","mån","tys","ons","tor","fre","lau" ],
+	dayNames: [ "sundag","måndag","tysdag","onsdag","torsdag","fredag","laurdag" ],
+	dayNamesMin: [ "su","må","ty","on","to","fr","la" ],
+	weekHeader: "Veke",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: ""
+};
+datepicker.setDefaults( datepicker.regional.nn );
+
+return datepicker.regional.nn;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-no.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-no.js
@@ -1,0 +1,50 @@
+/* Norwegian initialisation for the jQuery UI date picker plugin. */
+/* Written by Naimdjon Takhirov (naimdjon@gmail.com). */
+
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.no = {
+	closeText: "Lukk",
+	prevText: "&#xAB;Forrige",
+	nextText: "Neste&#xBB;",
+	currentText: "I dag",
+	monthNames: [
+		"januar",
+		"februar",
+		"mars",
+		"april",
+		"mai",
+		"juni",
+		"juli",
+		"august",
+		"september",
+		"oktober",
+		"november",
+		"desember"
+	],
+	monthNamesShort: [ "jan","feb","mar","apr","mai","jun","jul","aug","sep","okt","nov","des" ],
+	dayNamesShort: [ "søn","man","tir","ons","tor","fre","lør" ],
+	dayNames: [ "søndag","mandag","tirsdag","onsdag","torsdag","fredag","lørdag" ],
+	dayNamesMin: [ "sø","ma","ti","on","to","fr","lø" ],
+	weekHeader: "Uke",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: ""
+};
+datepicker.setDefaults( datepicker.regional.no );
+
+return datepicker.regional.no;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-pl.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-pl.js
@@ -1,0 +1,37 @@
+/* Polish initialisation for the jQuery UI date picker plugin. */
+/* Written by Jacek Wysocki (jacek.wysocki@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.pl = {
+	closeText: "Zamknij",
+	prevText: "&#x3C;Poprzedni",
+	nextText: "Następny&#x3E;",
+	currentText: "Dziś",
+	monthNames: [ "Styczeń","Luty","Marzec","Kwiecień","Maj","Czerwiec",
+	"Lipiec","Sierpień","Wrzesień","Październik","Listopad","Grudzień" ],
+	monthNamesShort: [ "Sty","Lu","Mar","Kw","Maj","Cze",
+	"Lip","Sie","Wrz","Pa","Lis","Gru" ],
+	dayNames: [ "Niedziela","Poniedziałek","Wtorek","Środa","Czwartek","Piątek","Sobota" ],
+	dayNamesShort: [ "Nie","Pn","Wt","Śr","Czw","Pt","So" ],
+	dayNamesMin: [ "N","Pn","Wt","Śr","Cz","Pt","So" ],
+	weekHeader: "Tydz",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.pl );
+
+return datepicker.regional.pl;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-pt-BR.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-pt-BR.js
@@ -1,0 +1,45 @@
+/* Brazilian initialisation for the jQuery UI date picker plugin. */
+/* Written by Leonildo Costa Silva (leocsilva@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "pt-BR" ] = {
+	closeText: "Fechar",
+	prevText: "&#x3C;Anterior",
+	nextText: "Próximo&#x3E;",
+	currentText: "Hoje",
+	monthNames: [ "Janeiro","Fevereiro","Março","Abril","Maio","Junho",
+	"Julho","Agosto","Setembro","Outubro","Novembro","Dezembro" ],
+	monthNamesShort: [ "Jan","Fev","Mar","Abr","Mai","Jun",
+	"Jul","Ago","Set","Out","Nov","Dez" ],
+	dayNames: [
+		"Domingo",
+		"Segunda-feira",
+		"Terça-feira",
+		"Quarta-feira",
+		"Quinta-feira",
+		"Sexta-feira",
+		"Sábado"
+	],
+	dayNamesShort: [ "Dom","Seg","Ter","Qua","Qui","Sex","Sáb" ],
+	dayNamesMin: [ "Dom","Seg","Ter","Qua","Qui","Sex","Sáb" ],
+	weekHeader: "Sm",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "pt-BR" ] );
+
+return datepicker.regional[ "pt-BR" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-pt.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-pt.js
@@ -1,0 +1,44 @@
+/* Portuguese initialisation for the jQuery UI date picker plugin. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.pt = {
+	closeText: "Fechar",
+	prevText: "Anterior",
+	nextText: "Seguinte",
+	currentText: "Hoje",
+	monthNames: [ "Janeiro","Fevereiro","Março","Abril","Maio","Junho",
+	"Julho","Agosto","Setembro","Outubro","Novembro","Dezembro" ],
+	monthNamesShort: [ "Jan","Fev","Mar","Abr","Mai","Jun",
+	"Jul","Ago","Set","Out","Nov","Dez" ],
+	dayNames: [
+		"Domingo",
+		"Segunda-feira",
+		"Terça-feira",
+		"Quarta-feira",
+		"Quinta-feira",
+		"Sexta-feira",
+		"Sábado"
+	],
+	dayNamesShort: [ "Dom","Seg","Ter","Qua","Qui","Sex","Sáb" ],
+	dayNamesMin: [ "Dom","Seg","Ter","Qua","Qui","Sex","Sáb" ],
+	weekHeader: "Sem",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.pt );
+
+return datepicker.regional.pt;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-rm.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-rm.js
@@ -1,0 +1,61 @@
+/* Romansh initialisation for the jQuery UI date picker plugin. */
+/* Written by Yvonne Gienal (yvonne.gienal@educa.ch). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.rm = {
+	closeText: "Serrar",
+	prevText: "&#x3C;Suandant",
+	nextText: "Precedent&#x3E;",
+	currentText: "Actual",
+	monthNames: [
+		"Schaner",
+		"Favrer",
+		"Mars",
+		"Avrigl",
+		"Matg",
+		"Zercladur",
+		"Fanadur",
+		"Avust",
+		"Settember",
+		"October",
+		"November",
+		"December"
+	],
+	monthNamesShort: [
+		"Scha",
+		"Fev",
+		"Mar",
+		"Avr",
+		"Matg",
+		"Zer",
+		"Fan",
+		"Avu",
+		"Sett",
+		"Oct",
+		"Nov",
+		"Dec"
+	],
+	dayNames: [ "Dumengia","Glindesdi","Mardi","Mesemna","Gievgia","Venderdi","Sonda" ],
+	dayNamesShort: [ "Dum","Gli","Mar","Mes","Gie","Ven","Som" ],
+	dayNamesMin: [ "Du","Gl","Ma","Me","Gi","Ve","So" ],
+	weekHeader: "emna",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.rm );
+
+return datepicker.regional.rm;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ro.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ro.js
@@ -1,0 +1,40 @@
+/* Romanian initialisation for the jQuery UI date picker plugin.
+ *
+ * Written by Edmond L. (ll_edmond@walla.com)
+ * and Ionut G. Stan (ionut.g.stan@gmail.com)
+ */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ro = {
+	closeText: "Închide",
+	prevText: "&#xAB; Luna precedentă",
+	nextText: "Luna următoare &#xBB;",
+	currentText: "Azi",
+	monthNames: [ "Ianuarie","Februarie","Martie","Aprilie","Mai","Iunie",
+	"Iulie","August","Septembrie","Octombrie","Noiembrie","Decembrie" ],
+	monthNamesShort: [ "Ian", "Feb", "Mar", "Apr", "Mai", "Iun",
+	"Iul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+	dayNames: [ "Duminică", "Luni", "Marţi", "Miercuri", "Joi", "Vineri", "Sâmbătă" ],
+	dayNamesShort: [ "Dum", "Lun", "Mar", "Mie", "Joi", "Vin", "Sâm" ],
+	dayNamesMin: [ "Du","Lu","Ma","Mi","Jo","Vi","Sâ" ],
+	weekHeader: "Săpt",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ro );
+
+return datepicker.regional.ro;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ru.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ru.js
@@ -1,0 +1,37 @@
+/* Russian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Andrew Stromnov (stromnov@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ru = {
+	closeText: "Закрыть",
+	prevText: "&#x3C;Пред",
+	nextText: "След&#x3E;",
+	currentText: "Сегодня",
+	monthNames: [ "Январь","Февраль","Март","Апрель","Май","Июнь",
+	"Июль","Август","Сентябрь","Октябрь","Ноябрь","Декабрь" ],
+	monthNamesShort: [ "Янв","Фев","Мар","Апр","Май","Июн",
+	"Июл","Авг","Сен","Окт","Ноя","Дек" ],
+	dayNames: [ "воскресенье","понедельник","вторник","среда","четверг","пятница","суббота" ],
+	dayNamesShort: [ "вск","пнд","втр","срд","чтв","птн","сбт" ],
+	dayNamesMin: [ "Вс","Пн","Вт","Ср","Чт","Пт","Сб" ],
+	weekHeader: "Нед",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ru );
+
+return datepicker.regional.ru;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sk.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sk.js
@@ -1,0 +1,37 @@
+/* Slovak initialisation for the jQuery UI date picker plugin. */
+/* Written by Vojtech Rinik (vojto@hmm.sk). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.sk = {
+	closeText: "Zavrieť",
+	prevText: "&#x3C;Predchádzajúci",
+	nextText: "Nasledujúci&#x3E;",
+	currentText: "Dnes",
+	monthNames: [ "január","február","marec","apríl","máj","jún",
+	"júl","august","september","október","november","december" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Máj","Jún",
+	"Júl","Aug","Sep","Okt","Nov","Dec" ],
+	dayNames: [ "nedeľa","pondelok","utorok","streda","štvrtok","piatok","sobota" ],
+	dayNamesShort: [ "Ned","Pon","Uto","Str","Štv","Pia","Sob" ],
+	dayNamesMin: [ "Ne","Po","Ut","St","Št","Pia","So" ],
+	weekHeader: "Ty",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.sk );
+
+return datepicker.regional.sk;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sl.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sl.js
@@ -1,0 +1,38 @@
+/* Slovenian initialisation for the jQuery UI date picker plugin. */
+/* Written by Jaka Jancar (jaka@kubje.org). */
+/* c = č, s = š z = ž C = Č S = Š Z = Ž */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.sl = {
+	closeText: "Zapri",
+	prevText: "&#x3C;Prejšnji",
+	nextText: "Naslednji&#x3E;",
+	currentText: "Trenutni",
+	monthNames: [ "Januar","Februar","Marec","April","Maj","Junij",
+	"Julij","Avgust","September","Oktober","November","December" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maj","Jun",
+	"Jul","Avg","Sep","Okt","Nov","Dec" ],
+	dayNames: [ "Nedelja","Ponedeljek","Torek","Sreda","Četrtek","Petek","Sobota" ],
+	dayNamesShort: [ "Ned","Pon","Tor","Sre","Čet","Pet","Sob" ],
+	dayNamesMin: [ "Ne","Po","To","Sr","Če","Pe","So" ],
+	weekHeader: "Teden",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.sl );
+
+return datepicker.regional.sl;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sq.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sq.js
@@ -1,0 +1,37 @@
+/* Albanian initialisation for the jQuery UI date picker plugin. */
+/* Written by Flakron Bytyqi (flakron@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.sq = {
+	closeText: "mbylle",
+	prevText: "&#x3C;mbrapa",
+	nextText: "Përpara&#x3E;",
+	currentText: "sot",
+	monthNames: [ "Janar","Shkurt","Mars","Prill","Maj","Qershor",
+	"Korrik","Gusht","Shtator","Tetor","Nëntor","Dhjetor" ],
+	monthNamesShort: [ "Jan","Shk","Mar","Pri","Maj","Qer",
+	"Kor","Gus","Sht","Tet","Nën","Dhj" ],
+	dayNames: [ "E Diel","E Hënë","E Martë","E Mërkurë","E Enjte","E Premte","E Shtune" ],
+	dayNamesShort: [ "Di","Hë","Ma","Më","En","Pr","Sh" ],
+	dayNamesMin: [ "Di","Hë","Ma","Më","En","Pr","Sh" ],
+	weekHeader: "Ja",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.sq );
+
+return datepicker.regional.sq;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sr-SR.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sr-SR.js
@@ -1,0 +1,37 @@
+/* Serbian i18n for the jQuery UI date picker plugin. */
+/* Written by Dejan Dimić. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "sr-SR" ] = {
+	closeText: "Zatvori",
+	prevText: "&#x3C;",
+	nextText: "&#x3E;",
+	currentText: "Danas",
+	monthNames: [ "Januar","Februar","Mart","April","Maj","Jun",
+	"Jul","Avgust","Septembar","Oktobar","Novembar","Decembar" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maj","Jun",
+	"Jul","Avg","Sep","Okt","Nov","Dec" ],
+	dayNames: [ "Nedelja","Ponedeljak","Utorak","Sreda","Četvrtak","Petak","Subota" ],
+	dayNamesShort: [ "Ned","Pon","Uto","Sre","Čet","Pet","Sub" ],
+	dayNamesMin: [ "Ne","Po","Ut","Sr","Če","Pe","Su" ],
+	weekHeader: "Sed",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "sr-SR" ] );
+
+return datepicker.regional[ "sr-SR" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sr.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sr.js
@@ -1,0 +1,37 @@
+/* Serbian i18n for the jQuery UI date picker plugin. */
+/* Written by Dejan Dimić. */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.sr = {
+	closeText: "Затвори",
+	prevText: "&#x3C;",
+	nextText: "&#x3E;",
+	currentText: "Данас",
+	monthNames: [ "Јануар","Фебруар","Март","Април","Мај","Јун",
+	"Јул","Август","Септембар","Октобар","Новембар","Децембар" ],
+	monthNamesShort: [ "Јан","Феб","Мар","Апр","Мај","Јун",
+	"Јул","Авг","Сеп","Окт","Нов","Дец" ],
+	dayNames: [ "Недеља","Понедељак","Уторак","Среда","Четвртак","Петак","Субота" ],
+	dayNamesShort: [ "Нед","Пон","Уто","Сре","Чет","Пет","Суб" ],
+	dayNamesMin: [ "Не","По","Ут","Ср","Че","Пе","Су" ],
+	weekHeader: "Сед",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.sr );
+
+return datepicker.regional.sr;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sv.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-sv.js
@@ -1,0 +1,37 @@
+/* Swedish initialisation for the jQuery UI date picker plugin. */
+/* Written by Anders Ekdahl ( anders@nomadiz.se). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.sv = {
+	closeText: "Stäng",
+	prevText: "&#xAB;Förra",
+	nextText: "Nästa&#xBB;",
+	currentText: "Idag",
+	monthNames: [ "Januari","Februari","Mars","April","Maj","Juni",
+	"Juli","Augusti","September","Oktober","November","December" ],
+	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maj","Jun",
+	"Jul","Aug","Sep","Okt","Nov","Dec" ],
+	dayNamesShort: [ "Sön","Mån","Tis","Ons","Tor","Fre","Lör" ],
+	dayNames: [ "Söndag","Måndag","Tisdag","Onsdag","Torsdag","Fredag","Lördag" ],
+	dayNamesMin: [ "Sö","Må","Ti","On","To","Fr","Lö" ],
+	weekHeader: "Ve",
+	dateFormat: "yy-mm-dd",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.sv );
+
+return datepicker.regional.sv;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ta.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-ta.js
@@ -1,0 +1,53 @@
+/* Tamil (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by S A Sureshkumar (saskumar@live.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.ta = {
+	closeText: "மூடு",
+	prevText: "முன்னையது",
+	nextText: "அடுத்தது",
+	currentText: "இன்று",
+	monthNames: [ "தை","மாசி","பங்குனி","சித்திரை","வைகாசி","ஆனி",
+	"ஆடி","ஆவணி","புரட்டாசி","ஐப்பசி","கார்த்திகை","மார்கழி" ],
+	monthNamesShort: [ "தை","மாசி","பங்","சித்","வைகா","ஆனி",
+	"ஆடி","ஆவ","புர","ஐப்","கார்","மார்" ],
+	dayNames: [
+		"ஞாயிற்றுக்கிழமை",
+		"திங்கட்கிழமை",
+		"செவ்வாய்க்கிழமை",
+		"புதன்கிழமை",
+		"வியாழக்கிழமை",
+		"வெள்ளிக்கிழமை",
+		"சனிக்கிழமை"
+	],
+	dayNamesShort: [
+		"ஞாயிறு",
+		"திங்கள்",
+		"செவ்வாய்",
+		"புதன்",
+		"வியாழன்",
+		"வெள்ளி",
+		"சனி"
+	],
+	dayNamesMin: [ "ஞா","தி","செ","பு","வி","வெ","ச" ],
+	weekHeader: "Не",
+	dateFormat: "dd/mm/yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.ta );
+
+return datepicker.regional.ta;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-th.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-th.js
@@ -1,0 +1,37 @@
+/* Thai initialisation for the jQuery UI date picker plugin. */
+/* Written by pipo (pipo@sixhead.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.th = {
+	closeText: "ปิด",
+	prevText: "&#xAB;&#xA0;ย้อน",
+	nextText: "ถัดไป&#xA0;&#xBB;",
+	currentText: "วันนี้",
+	monthNames: [ "มกราคม","กุมภาพันธ์","มีนาคม","เมษายน","พฤษภาคม","มิถุนายน",
+	"กรกฎาคม","สิงหาคม","กันยายน","ตุลาคม","พฤศจิกายน","ธันวาคม" ],
+	monthNamesShort: [ "ม.ค.","ก.พ.","มี.ค.","เม.ย.","พ.ค.","มิ.ย.",
+	"ก.ค.","ส.ค.","ก.ย.","ต.ค.","พ.ย.","ธ.ค." ],
+	dayNames: [ "อาทิตย์","จันทร์","อังคาร","พุธ","พฤหัสบดี","ศุกร์","เสาร์" ],
+	dayNamesShort: [ "อา.","จ.","อ.","พ.","พฤ.","ศ.","ส." ],
+	dayNamesMin: [ "อา.","จ.","อ.","พ.","พฤ.","ศ.","ส." ],
+	weekHeader: "Wk",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.th );
+
+return datepicker.regional.th;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-tj.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-tj.js
@@ -1,0 +1,37 @@
+/* Tajiki (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Abdurahmon Saidov (saidovab@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.tj = {
+	closeText: "Идома",
+	prevText: "&#x3c;Қафо",
+	nextText: "Пеш&#x3e;",
+	currentText: "Имрӯз",
+	monthNames: [ "Январ","Феврал","Март","Апрел","Май","Июн",
+	"Июл","Август","Сентябр","Октябр","Ноябр","Декабр" ],
+	monthNamesShort: [ "Янв","Фев","Мар","Апр","Май","Июн",
+	"Июл","Авг","Сен","Окт","Ноя","Дек" ],
+	dayNames: [ "якшанбе","душанбе","сешанбе","чоршанбе","панҷшанбе","ҷумъа","шанбе" ],
+	dayNamesShort: [ "якш","душ","сеш","чор","пан","ҷум","шан" ],
+	dayNamesMin: [ "Як","Дш","Сш","Чш","Пш","Ҷм","Шн" ],
+	weekHeader: "Хф",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.tj );
+
+return datepicker.regional.tj;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-tr.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-tr.js
@@ -1,0 +1,37 @@
+/* Turkish initialisation for the jQuery UI date picker plugin. */
+/* Written by Izzet Emre Erkan (kara@karalamalar.net). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.tr = {
+	closeText: "kapat",
+	prevText: "&#x3C;geri",
+	nextText: "ileri&#x3e",
+	currentText: "bugün",
+	monthNames: [ "Ocak","Şubat","Mart","Nisan","Mayıs","Haziran",
+	"Temmuz","Ağustos","Eylül","Ekim","Kasım","Aralık" ],
+	monthNamesShort: [ "Oca","Şub","Mar","Nis","May","Haz",
+	"Tem","Ağu","Eyl","Eki","Kas","Ara" ],
+	dayNames: [ "Pazar","Pazartesi","Salı","Çarşamba","Perşembe","Cuma","Cumartesi" ],
+	dayNamesShort: [ "Pz","Pt","Sa","Ça","Pe","Cu","Ct" ],
+	dayNamesMin: [ "Pz","Pt","Sa","Ça","Pe","Cu","Ct" ],
+	weekHeader: "Hf",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.tr );
+
+return datepicker.regional.tr;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-uk.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-uk.js
@@ -1,0 +1,38 @@
+/* Ukrainian (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Maxim Drogobitskiy (maxdao@gmail.com). */
+/* Corrected by Igor Milla (igor.fsp.milla@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.uk = {
+	closeText: "Закрити",
+	prevText: "&#x3C;",
+	nextText: "&#x3E;",
+	currentText: "Сьогодні",
+	monthNames: [ "Січень","Лютий","Березень","Квітень","Травень","Червень",
+	"Липень","Серпень","Вересень","Жовтень","Листопад","Грудень" ],
+	monthNamesShort: [ "Січ","Лют","Бер","Кві","Тра","Чер",
+	"Лип","Сер","Вер","Жов","Лис","Гру" ],
+	dayNames: [ "неділя","понеділок","вівторок","середа","четвер","п’ятниця","субота" ],
+	dayNamesShort: [ "нед","пнд","вів","срд","чтв","птн","сбт" ],
+	dayNamesMin: [ "Нд","Пн","Вт","Ср","Чт","Пт","Сб" ],
+	weekHeader: "Тиж",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.uk );
+
+return datepicker.regional.uk;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-vi.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-vi.js
@@ -1,0 +1,37 @@
+/* Vietnamese initialisation for the jQuery UI date picker plugin. */
+/* Translated by Le Thanh Huy (lthanhhuy@cit.ctu.edu.vn). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.vi = {
+	closeText: "Đóng",
+	prevText: "&#x3C;Trước",
+	nextText: "Tiếp&#x3E;",
+	currentText: "Hôm nay",
+	monthNames: [ "Tháng Một", "Tháng Hai", "Tháng Ba", "Tháng Tư", "Tháng Năm", "Tháng Sáu",
+	"Tháng Bảy", "Tháng Tám", "Tháng Chín", "Tháng Mười", "Tháng Mười Một", "Tháng Mười Hai" ],
+	monthNamesShort: [ "Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6",
+	"Tháng 7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12" ],
+	dayNames: [ "Chủ Nhật", "Thứ Hai", "Thứ Ba", "Thứ Tư", "Thứ Năm", "Thứ Sáu", "Thứ Bảy" ],
+	dayNamesShort: [ "CN", "T2", "T3", "T4", "T5", "T6", "T7" ],
+	dayNamesMin: [ "CN", "T2", "T3", "T4", "T5", "T6", "T7" ],
+	weekHeader: "Tu",
+	dateFormat: "dd/mm/yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional.vi );
+
+return datepicker.regional.vi;
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-zh-CN.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-zh-CN.js
@@ -1,0 +1,37 @@
+/* Chinese initialisation for the jQuery UI date picker plugin. */
+/* Written by Cloudream (cloudream@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "zh-CN" ] = {
+	closeText: "关闭",
+	prevText: "&#x3C;上月",
+	nextText: "下月&#x3E;",
+	currentText: "今天",
+	monthNames: [ "一月","二月","三月","四月","五月","六月",
+	"七月","八月","九月","十月","十一月","十二月" ],
+	monthNamesShort: [ "一月","二月","三月","四月","五月","六月",
+	"七月","八月","九月","十月","十一月","十二月" ],
+	dayNames: [ "星期日","星期一","星期二","星期三","星期四","星期五","星期六" ],
+	dayNamesShort: [ "周日","周一","周二","周三","周四","周五","周六" ],
+	dayNamesMin: [ "日","一","二","三","四","五","六" ],
+	weekHeader: "周",
+	dateFormat: "yy-mm-dd",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: true,
+	yearSuffix: "年" };
+datepicker.setDefaults( datepicker.regional[ "zh-CN" ] );
+
+return datepicker.regional[ "zh-CN" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-zh-HK.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-zh-HK.js
@@ -1,0 +1,37 @@
+/* Chinese initialisation for the jQuery UI date picker plugin. */
+/* Written by SCCY (samuelcychan@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "zh-HK" ] = {
+	closeText: "關閉",
+	prevText: "&#x3C;上月",
+	nextText: "下月&#x3E;",
+	currentText: "今天",
+	monthNames: [ "一月","二月","三月","四月","五月","六月",
+	"七月","八月","九月","十月","十一月","十二月" ],
+	monthNamesShort: [ "一月","二月","三月","四月","五月","六月",
+	"七月","八月","九月","十月","十一月","十二月" ],
+	dayNames: [ "星期日","星期一","星期二","星期三","星期四","星期五","星期六" ],
+	dayNamesShort: [ "周日","周一","周二","周三","周四","周五","周六" ],
+	dayNamesMin: [ "日","一","二","三","四","五","六" ],
+	weekHeader: "周",
+	dateFormat: "dd-mm-yy",
+	firstDay: 0,
+	isRTL: false,
+	showMonthAfterYear: true,
+	yearSuffix: "年" };
+datepicker.setDefaults( datepicker.regional[ "zh-HK" ] );
+
+return datepicker.regional[ "zh-HK" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-zh-TW.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/datepicker/i18n/datepicker-zh-TW.js
@@ -1,0 +1,37 @@
+/* Chinese initialisation for the jQuery UI date picker plugin. */
+/* Written by Ressol (ressol@gmail.com). */
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "zh-TW" ] = {
+	closeText: "關閉",
+	prevText: "&#x3C;上月",
+	nextText: "下月&#x3E;",
+	currentText: "今天",
+	monthNames: [ "一月","二月","三月","四月","五月","六月",
+	"七月","八月","九月","十月","十一月","十二月" ],
+	monthNamesShort: [ "一月","二月","三月","四月","五月","六月",
+	"七月","八月","九月","十月","十一月","十二月" ],
+	dayNames: [ "星期日","星期一","星期二","星期三","星期四","星期五","星期六" ],
+	dayNamesShort: [ "周日","周一","周二","周三","周四","周五","周六" ],
+	dayNamesMin: [ "日","一","二","三","四","五","六" ],
+	weekHeader: "周",
+	dateFormat: "yy/mm/dd",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: true,
+	yearSuffix: "年" };
+datepicker.setDefaults( datepicker.regional[ "zh-TW" ] );
+
+return datepicker.regional[ "zh-TW" ];
+
+} ) );

--- a/wiquery-jquery-ui/src/test/java/org/wicketstuff/wiquery/ui/datepicker/DatePickerLanguageResourceReferenceTestCase.java
+++ b/wiquery-jquery-ui/src/test/java/org/wicketstuff/wiquery/ui/datepicker/DatePickerLanguageResourceReferenceTestCase.java
@@ -1,0 +1,84 @@
+package org.wicketstuff.wiquery.ui.datepicker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Locale;
+
+import org.apache.wicket.Application;
+import org.apache.wicket.core.util.resource.locator.IResourceStreamLocator;
+import org.apache.wicket.util.lang.Packages;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wicketstuff.wiquery.tester.WiQueryTestCase;
+import org.wicketstuff.wiquery.ui.datepicker.DatePickerLanguageResourceReference;
+import org.wicketstuff.wiquery.ui.datepicker.DatePickerLanguageResourceReference.DatePickerLanguages;
+
+/**
+ * Unit test on the {@link DatePickerLanguageResourceReference}
+ * 
+ * @author Julien Roche
+ * @author Hielke Hoeve
+ */
+public class DatePickerLanguageResourceReferenceTestCase extends WiQueryTestCase
+{
+
+	protected static final Logger log = LoggerFactory
+		.getLogger(DatePickerLanguageResourceReferenceTestCase.class);
+
+	@Test
+	public void testGetDatePickerLanguages()
+	{
+		Locale nonavailableLocale = new Locale("wiquery");
+		Locale availableLocale = DatePickerLanguages.ARMENIAN.getLocale();
+
+		assertNull(DatePickerLanguages.getDatePickerLanguages(nonavailableLocale));
+		assertNull(DatePickerLanguageResourceReference.get(nonavailableLocale));
+
+		assertNotNull(DatePickerLanguages.getDatePickerLanguages(availableLocale));
+		assertNotNull(DatePickerLanguageResourceReference.get(availableLocale));
+
+		for (DatePickerLanguages language : DatePickerLanguages.values())
+		{
+			// assert if the language getter is implemented correctly to return
+			// the exact variant.
+			assertEquals(language, DatePickerLanguages.getDatePickerLanguages(language.getLocale()));
+
+			// assert if the reference getter is implemented correctly to return
+			// a reference to the exact variant.
+			DatePickerLanguageResourceReference ref =
+				DatePickerLanguageResourceReference.get(language.getLocale());
+			assertNotNull(ref);
+
+			// assert if the file is actually there.
+			IResourceStreamLocator locator =
+				Application.get().getResourceSettings().getResourceStreamLocator();
+			String absolutePath =
+				Packages.absolutePath(DatePickerLanguageResourceReference.class,
+					DatePickerLanguages.getJsFileName(language));
+			assertNotNull("Resource " + DatePickerLanguages.getJsFileName(language)
+				+ " for locale " + language.getLocale() + " does not exist!",
+				locator.locate(DatePickerLanguageResourceReference.class, absolutePath));
+		}
+	}
+
+	@Test
+	public void testGetJsFileName()
+	{
+		assertNull(DatePickerLanguages.getJsFileName(null));
+
+		assertEquals(DatePickerLanguages.getJsFileName(DatePickerLanguages.FRENCH).toString(),
+			"i18n/datepicker-fr.js");
+
+		assertEquals(DatePickerLanguages.getJsFileName(DatePickerLanguages.SERBIA).toString(),
+			"i18n/datepicker-sr-SR.js");
+	}
+
+	@Override
+	protected Logger getLog()
+	{
+		return log;
+	}
+}


### PR DESCRIPTION
See issue #3.

Duplicate files/locales (see note on `DatePickerLanguages` inner class), need to be checked:
- Hebrew: "he" resource file copied to "iw".
- Indonesian: "id" resource file copied to "in".
- Kazakh: "kk" resource file copied to "kz".

New locales (see `DatePickerLanguages`), need to be checked:
- `BELARUSIAN("be")`
- `SWISS_ITALIAN("it", "CH")`