### PR TITLE
Put back language resource for inline date picker.

### DIFF
--- a/wiquery-jquery-ui/src/main/java/org/wicketstuff/wiquery/ui/datepicker/InlineDatePicker.java
+++ b/wiquery-jquery-ui/src/main/java/org/wicketstuff/wiquery/ui/datepicker/InlineDatePicker.java
@@ -87,6 +87,11 @@ public class InlineDatePicker<T> extends WebMarkupContainer
 		response
 			.render(JavaScriptHeaderItem.forReference(JQueryUIJavaScriptResourceReference.get()));
 
+		DatePickerLanguageResourceReference dpl =
+			DatePickerLanguageResourceReference.get(getLocale());
+		if (dpl != null)
+			response.render(JavaScriptHeaderItem.forReference(dpl));
+
 		response.render(OnDomReadyHeaderItem.forScript(new JsQuery(this).$()
 			.chain("datepicker", options.getOptions().getJavaScriptOptions())
 			.render()


### PR DESCRIPTION
Hi,

This PR follows ticket #3 and PR #4.

We forgot to take care of `InlineDatePicker` and put back `DatePickerLanguageResourceReference` dependency.

Florian