### PR TITLE
Specifying var source as String object explicitly to avoid the error

### DIFF
--- a/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/autocomplete/wiquery-autocomplete.js
+++ b/wiquery-jquery-ui/src/main/resources/org/wicketstuff/wiquery/ui/autocomplete/wiquery-autocomplete.js
@@ -43,7 +43,7 @@
 	
 			} else {
 			  	var find = null;
-			  	var source = $(event.target).autocomplete('option', 'source');
+			  	var source = new String($(event.target).autocomplete('option', 'source'));
 			  	
 			  	var matcher = new RegExp( "^" + val + "$", "i" );
 	


### PR DESCRIPTION
Specifying var source as String object explicitly to avoid the error when 'in' operator used on String in jquery-2.2.4.js