### PR TITLE
Update README.md and dependencies in the wiquery 9 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# WiQuery for Apache Wicket 8.x
+# WiQuery for Apache Wicket 9.x
 
 WiQuery is a project to simply Wicket integration with jQuery and jQuery UI.
 
-This branch follows the development of Apache Wicket 8.x (the master branch of Apache Wicket)
+This branch follows the development of Apache Wicket 9.x (the master branch of Apache Wicket)
 
 WiQuery consists of 3 subprojects:
 - core - the core library
@@ -13,9 +13,9 @@ WiQuery consists of 3 subprojects:
 
 WiQuery requires the following:
 
-- Java 8
-- Servlet 3.1 
-- Wicket 8.0 or newer
+- Java 11
+- Servlet 4.0 
+- Wicket 9.0 or newer
 
 Newer or older major releases of Wicket are not compatible with this version of WiQuery.
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 
 		<wicket.version>9.17.0</wicket.version>
-		<jackson.version>2.17.1</jackson.version>
+		<jackson.version>2.14.3</jackson.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<junit.version>5.10.2</junit.version>
 		<servlet-api.version>4.0.1</servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<groupId>org.wicketstuff.wiquery</groupId>
 	<artifactId>wiquery-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>9.0.0-SNAPSHOT</version>
+	<version>9.1.0-SNAPSHOT</version>
 	<name>WiQuery Parent</name>
 
 	<licenses>
@@ -29,8 +29,8 @@
 		<url>git://github.com/wicketstuff/wiquery.git</url>
 		<connection>scm:git:git://github.com/wicketstuff/wiquery.git</connection>
 		<developerConnection>scm:git:git@github.com:wicketstuff/wiquery.git</developerConnection>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<profiles>
 		<profile>
@@ -60,12 +60,12 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
 
-		<wicket.version>9.7.0</wicket.version>
-		<jackson.version>2.12.5</jackson.version>
-		<slf4j.version>1.7.25</slf4j.version>
-		<junit.version>5.8.2</junit.version>
+		<wicket.version>9.17.0</wicket.version>
+		<jackson.version>2.17.1</jackson.version>
+		<slf4j.version>1.7.36</slf4j.version>
+		<junit.version>5.10.2</junit.version>
 		<servlet-api.version>4.0.1</servlet-api.version>
-		<jetty.version>9.4.44.v20210927</jetty.version>
+		<jetty.version>9.4.54.v20240208</jetty.version>
 	</properties>
 
 	<modules>

--- a/wiquery-core/pom.xml
+++ b/wiquery-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff.wiquery</groupId>
 		<artifactId>wiquery-parent</artifactId>
-		<version>9.0.0-SNAPSHOT</version>
+		<version>9.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wiquery-core</artifactId>

--- a/wiquery-demo/pom.xml
+++ b/wiquery-demo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wiquery-parent</artifactId>
 		<groupId>org.wicketstuff.wiquery</groupId>
-		<version>9.0.0-SNAPSHOT</version>
+		<version>9.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wiquery-demo</artifactId>

--- a/wiquery-jquery-ui/pom.xml
+++ b/wiquery-jquery-ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff.wiquery</groupId>
 		<artifactId>wiquery-parent</artifactId>
-		<version>9.0.0-SNAPSHOT</version>
+		<version>9.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wiquery-jquery-ui</artifactId>


### PR DESCRIPTION
Update README.md in the wiquery 9 branch
- Wicket `8` -> `9`
- Java `8` -> `11`
- Servlet `3.1` -> `4.0` 

Update dependencies
- Wicket `9.7.0` -> `9.17.0`
- Jackson `2.12.5` -> `2.17.1`
- SLF4J `1.7.25` -> `1.7.36`
- JUnit `5.8.2` -> `5.10.2`
- Jetty `9.4.44.v20210927` -> `9.4.54.v20240208`